### PR TITLE
Correct version range syntax for peers

### DIFF
--- a/middleware/logger-provider/package.json
+++ b/middleware/logger-provider/package.json
@@ -31,7 +31,7 @@
     "@codeplant-de/nodejs-server-logger": "^2.0.1"
   },
   "peerDependencies": {
-    "@codeplant-de/nodejs-server-logger": "^1.1.0 | ^2.0.0"
+    "@codeplant-de/nodejs-server-logger": "^1.1.0 || ^2.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -41,7 +41,7 @@
     "supertest": "^6.3.3"
   },
   "peerDependencies": {
-    "@codeplant-de/nodejs-server-logger": "^1.1.0 | ^2.0.0"
+    "@codeplant-de/nodejs-server-logger": "^1.1.0 || ^2.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
The correct syntax is two pipes. This should fix warnings like this:
```
├─┬ @codeplant-de/nodejs-server-middleware 1.1.12
│ ├── ✕ unmet peer @codeplant-de/nodejs-server-logger@"^1.1.0 | ^2.0.0": found 2.0.1
```