### PR TITLE
Fix implicit Jest dependency in test utils

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,6 +29,14 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1"
   },
+  "peerDependencies": {
+    "jest": "^29.6.2"
+  },
+  "peerDependenciesMeta": {
+    "jest": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -30,7 +30,7 @@
     "ts-node": "^10.9.1"
   },
   "peerDependencies": {
-    "jest": "^29.6.2"
+    "jest": "^29.6.2 || ^30.0.4"
   },
   "peerDependenciesMeta": {
     "jest": {


### PR DESCRIPTION
`@codeplant-de/nodejs-server-logger/test` relies on types from `@jest/expect`, but only has Jest as a dev dependency. I think it just ends up working the same as a peer dependency in the end, where it gets resolved to whatever is installed in the project importing this package. But that project could be using an incompatible version of Jest, in which case we want a warning. Currently, there's nothing.

Another thing is that the import is from `@jest/expect`, but only `jest` is declared as a dependency of any type. However, `jest` should install `@jest/expect`. I imagine that people usually don't add these individual components of Jest to their projects, so it would be inconvenient to be forced to do that just for one package that requires it as a peer dependency.

Alternatively, we could simply make `@jest/expect` a regular dependency. But the types in the package and the consuming project have to exactly align. It would be annoying not to be able to update to Jest v30.2.0 because this package relies on Jest v30.0.0 (I've ran into the problem with type incompatibility between these two versions).