### PR TITLE
chore: add CI, Claude Code config, and comprehensive test coverage

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,112 @@
+---
+name: code-reviewer
+description: Use this agent when the user requests a pull request review or when a logical chunk of work has been completed and pushed to a PR branch. This agent should be invoked proactively after significant code changes are committed and pushed, or when explicitly requested by the user.
+tools: Glob, Grep, Read, WebFetch, TodoWrite, WebSearch, Bash
+model: opus
+color: pink
+---
+
+You are an elite code reviewer with deep expertise in TypeScript, Node.js, Express/Connect middleware, and library design. Your role is to conduct thorough, constructive pull request reviews that maintain the highest code quality standards while being respectful and educational.
+
+## Core Responsibilities
+
+1. **Comprehensive Code Analysis**: Review all changes for code quality, correctness, security, performance, and adherence to project standards.
+
+2. **Context-Aware Review**: Always begin by gathering complete context:
+    - Read ALL existing PR comments to avoid repetition
+    - Check git log to understand the commit history
+    - Identify commits added since the last review
+    - Understand the broader codebase context around the changes
+
+3. **Incremental Review Focus**: When previous reviews exist, focus primarily on:
+    - New commits since the last review
+    - Issues that may have been overlooked in previous reviews
+    - Verification that previous feedback has been addressed
+    - Do NOT repeat comments already made unless they remain unaddressed
+
+4. **External Dependencies Verification**: For any external services, libraries, or infrastructure:
+    - Check official documentation for the specific version being used
+    - Verify usage patterns match current best practices
+    - Ensure latest stable versions are used (unless there's a documented reason for otherwise)
+    - Flag usage of outdated patterns or deprecated APIs
+
+## Review Methodology
+
+### Phase 1: Context Gathering
+1. Use `gh pr view` to get PR details and existing comments
+2. Use `git log` to understand commit history
+3. Identify what has changed since any previous review
+
+### Phase 2: Code Analysis
+Evaluate changes against these criteria:
+
+**Code Quality & Best Practices**:
+- Adherence to project's TypeScript strict mode requirements
+- Proper use of types and interfaces (avoid unnecessary `any` casts)
+- Correct middleware patterns (Connect-compatible signature)
+- Code reuse and DRY principles
+- Consistency with existing codebase patterns
+- Proper use of AsyncLocalStorage patterns
+
+**Architecture & Design**:
+- Appropriate separation of concerns
+- Correct dependency flow (middleware → logger, not the reverse)
+- Proper use of Lerna independent versioning
+- CJS + types build output correctness
+- Peer dependency declarations
+
+**Security**:
+- Input validation and sanitization
+- Secure handling of request data
+- No information leakage in logs
+
+**Performance**:
+- Efficient middleware chains
+- Proper async handling
+- Avoiding unnecessary allocations in hot paths
+
+**Testing**:
+- Adequate test coverage for new functionality
+- Tests for edge cases and error conditions
+- Proper use of Jest mocks and assertions
+
+### Phase 3: Feedback Delivery
+
+**For Specific Code Issues**:
+- Use `gh pr comment` with code references for specific lines
+- Be precise about the issue and provide concrete suggestions
+- Include code examples when helpful
+- Explain the reasoning behind your feedback
+
+**For General Feedback**:
+- Use `gh pr comment` for top-level observations
+- Provide overall assessment and any broader concerns
+- Acknowledge good practices and improvements
+
+## Critical Rules
+
+1. **Never Repeat Comments**: If an issue has already been raised in previous reviews or comments, do not mention it again unless it remains unaddressed.
+
+2. **Focus on New Changes**: When reviewing an updated PR, concentrate on commits added since the last review.
+
+3. **Verify External Dependencies**: Always check documentation and source code for external libraries and services to ensure correct usage.
+
+4. **No Assumptions**: If you cannot verify something or lack necessary context, explicitly state this rather than making assumptions.
+
+5. **Be Constructive**: Frame feedback positively and educationally. Explain not just what is wrong, but why and how to improve it.
+
+6. **Respect Project Standards**: The project has strong opinions about consistency. Always prefer existing patterns over theoretically better alternatives unless changing the pattern is the explicit goal.
+
+7. **Silent When Appropriate**: If there are truly no new issues to raise and previous feedback has been adequately addressed, it's acceptable to post a brief approval comment rather than forcing feedback.
+
+## Output Format
+
+Your review should consist of:
+1. A top-level comment (using `gh pr comment`) that:
+    - Provides overall assessment
+    - Lists specific code issues with file:line references
+    - Highlights any broader concerns
+    - Acknowledges positive aspects of the changes
+    - States whether the PR is ready to merge or needs changes
+
+Remember: Your goal is to maintain exceptional code quality while fostering a positive, learning-oriented development culture. Be thorough but respectful, critical but constructive.

--- a/.claude/agents/programmer.md
+++ b/.claude/agents/programmer.md
@@ -1,0 +1,18 @@
+---
+name: programmer
+description: General-purpose programming agent for implementing features, fixing bugs, and writing code. Use this agent to delegate implementation tasks that follow established patterns and conventions. Ideal for parallelizing independent coding work.
+model: sonnet
+color: blue
+---
+
+You are a programmer working on the nodejs-server-utils Lerna monorepo. Your job is to implement what's been delegated to you — features, bug fixes, refactors, or other coding tasks.
+
+## How You Work
+
+1. **Research first.** Before writing any code, search the codebase for existing patterns, components, and utilities relevant to your task. Never guess at implementations.
+2. **Follow CLAUDE.md.** All project conventions, workflows, and coding standards are defined there. Read and follow them exactly.
+3. **Run quality checks** for every package you modified when you're done:
+   - `npm run typecheck` (from the package directory)
+   - `npm test` (from the package directory)
+4. **Self-review.** Run `git diff` and review your own changes before reporting back.
+5. **Report back** with a summary of what you did and any issues or blockers you encountered.

--- a/.claude/hooks/lint-and-format.sh
+++ b/.claude/hooks/lint-and-format.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# PostToolUse hook: auto-format and lint files after Edit/Write
+
+set -euo pipefail
+
+# Read stdin JSON and extract the file path
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+# Skip if no file path or file doesn't exist
+if [ -z "$FILE_PATH" ] || [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Only process TypeScript/JavaScript files
+case "$FILE_PATH" in
+  *.ts|*.tsx|*.js|*.jsx|*.mjs|*.cjs) ;;
+  *) exit 0 ;;
+esac
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# Run prettier (using locally installed version)
+"$PROJECT_DIR/node_modules/.bin/prettier" --write "$FILE_PATH" 2>/dev/null || true
+
+# Run eslint with auto-fix (using locally installed version)
+"$PROJECT_DIR/node_modules/.bin/eslint" --fix "$FILE_PATH" 2>/dev/null || true
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lint-and-format.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Typecheck
+        run: yarn lerna run typecheck
+
+      - name: Lint
+        run: yarn lerna run lint
+
+      - name: Test
+        run: yarn test

--- a/middleware/apollo-server-logging/src/defaults/contextToMetaFormatter.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/contextToMetaFormatter.test.ts
@@ -1,0 +1,13 @@
+import {defaultContextToMetaFormatter} from './contextToMetaFormatter'
+
+describe('defaults', () => {
+  describe('defaultContextToMetaFormatter', () => {
+    it('returns undefined regardless of input', () => {
+      expect(defaultContextToMetaFormatter({})).toBeUndefined()
+    })
+
+    it('returns undefined for a context with data', () => {
+      expect(defaultContextToMetaFormatter({userId: 1, role: 'admin'})).toBeUndefined()
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/defaults/errorMessageTemplate.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/errorMessageTemplate.test.ts
@@ -47,5 +47,29 @@ describe('defaults', () => {
         )
       })
     })
+
+    describe('multiple errors', () => {
+      it('uses plural "errors" when multiple error codes are present', () => {
+        const mockReq = {operationName: 'TestOp'}
+
+        const err1 = new GraphQLError('err1', {extensions: {code: 'CODE_A'}})
+        const err2 = new GraphQLError('err2', {extensions: {code: 'CODE_B'}})
+
+        expect(defaultErrorMessageTemplate(mockReq, {}, {}, [err1, err2])).toEqual(
+          '-X GQL: "CODE_A", "CODE_B" errors while processing TestOp'
+        )
+      })
+
+      it('only includes errors that have codes', () => {
+        const mockReq = {operationName: 'TestOp'}
+
+        const err1 = new GraphQLError('err1', {extensions: {code: 'HAS_CODE'}})
+        const err2 = new GraphQLError('err2')
+
+        expect(defaultErrorMessageTemplate(mockReq, {}, {}, [err1, err2])).toEqual(
+          '-X GQL: "HAS_CODE" error while processing TestOp'
+        )
+      })
+    })
   })
 })

--- a/middleware/apollo-server-logging/src/defaults/errorToMetaFormatter.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/errorToMetaFormatter.test.ts
@@ -1,0 +1,28 @@
+import {defaultErrorToMetaFormatter} from './errorToMetaFormatter'
+
+describe('defaults', () => {
+  describe('defaultErrorToMetaFormatter', () => {
+    it('returns a shallow copy of the error object', () => {
+      const err = {message: 'test-error', extensions: {code: 'MY_CODE'}}
+
+      const result = defaultErrorToMetaFormatter(err)
+
+      expect(result).toStrictEqual({message: 'test-error', extensions: {code: 'MY_CODE'}})
+    })
+
+    it('spreads the error properties into a new object', () => {
+      const err = {message: 'test-error'}
+
+      const result = defaultErrorToMetaFormatter(err)
+
+      expect(result).not.toBe(err)
+      expect(result).toStrictEqual({message: 'test-error'})
+    })
+
+    it('handles an error with no extra properties', () => {
+      const err = {message: 'simple'}
+
+      expect(defaultErrorToMetaFormatter(err)).toStrictEqual({message: 'simple'})
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/defaults/levelFunction.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/levelFunction.test.ts
@@ -1,0 +1,23 @@
+import {defaultLevelFunction} from './levelFunction'
+
+describe('defaults', () => {
+  describe('defaultLevelFunction', () => {
+    it('returns "info" when no errors are provided', () => {
+      expect(defaultLevelFunction({}, {}, {}, undefined)).toEqual('info')
+    })
+
+    it('returns "info" when errors array is empty', () => {
+      expect(defaultLevelFunction({}, {}, {}, [])).toEqual('info')
+    })
+
+    it('returns "error" when at least one error is present', () => {
+      expect(defaultLevelFunction({}, {}, {}, [{message: 'err'}])).toEqual('error')
+    })
+
+    it('returns "error" when multiple errors are present', () => {
+      expect(defaultLevelFunction({}, {}, {}, [{message: 'err1'}, {message: 'err2'}])).toEqual(
+        'error'
+      )
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/defaults/messageTemplate.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/messageTemplate.test.ts
@@ -1,0 +1,29 @@
+import {defaultMessageTemplate} from './messageTemplate'
+
+describe('defaults', () => {
+  describe('defaultMessageTemplate', () => {
+    it('returns a message containing the operation name', () => {
+      const mockReq = {operationName: 'TestOp'}
+
+      expect(defaultMessageTemplate(mockReq, {}, {})).toEqual('-> GQL: processed TestOp')
+    })
+
+    it('handles undefined operation name', () => {
+      const mockReq = {operationName: undefined}
+
+      expect(defaultMessageTemplate(mockReq, {}, {})).toEqual('-> GQL: processed undefined')
+    })
+
+    it('handles empty string operation name', () => {
+      const mockReq = {operationName: ''}
+
+      expect(defaultMessageTemplate(mockReq, {}, {})).toEqual('-> GQL: processed ')
+    })
+
+    it('handles null operation name', () => {
+      const mockReq = {operationName: null as any}
+
+      expect(defaultMessageTemplate(mockReq, {}, {})).toEqual('-> GQL: processed null')
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/defaults/requestToMetaFormatter.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/requestToMetaFormatter.test.ts
@@ -1,4 +1,75 @@
-import {filterSensitiveVariablesHelper} from './requestToMetaFormatter'
+import {NA_IP, NA_OPERATION_NAME} from '../constants'
+import {
+  filterSensitiveVariablesHelper,
+  getIpFromGraphQLRequest,
+  defaultRequestToMetaFormatter,
+} from './requestToMetaFormatter'
+
+describe('getIpFromGraphQLRequest', () => {
+  it('returns null when req.http is undefined', () => {
+    expect(getIpFromGraphQLRequest({} as any)).toBeNull()
+  })
+
+  it('returns null when x-forwarded-for header is absent', () => {
+    const req = {http: {headers: new Map()}}
+    expect(getIpFromGraphQLRequest(req as any)).toBeNull()
+  })
+
+  it('returns the first IP from a comma-separated x-forwarded-for', () => {
+    const headers = new Map([['x-forwarded-for', '10.0.0.1, 10.0.0.2']])
+    const req = {http: {headers}}
+    expect(getIpFromGraphQLRequest(req as any)).toBe('10.0.0.1')
+  })
+
+  it('returns a single IP from x-forwarded-for', () => {
+    const headers = new Map([['x-forwarded-for', '192.168.1.1']])
+    const req = {http: {headers}}
+    expect(getIpFromGraphQLRequest(req as any)).toBe('192.168.1.1')
+  })
+})
+
+describe('defaultRequestToMetaFormatter', () => {
+  it('returns operationName, clientIp, and filtered variables for a complete request', () => {
+    const headers = new Map([['x-forwarded-for', '1.2.3.4']])
+    const req = {
+      operationName: 'GetUser',
+      variables: {id: '123', password: 'secret'},
+      http: {headers},
+    }
+
+    const result = defaultRequestToMetaFormatter(req as any)
+
+    expect(result).toStrictEqual({
+      operationName: 'GetUser',
+      clientIp: '1.2.3.4',
+      variables: {id: '123', password: '[FILTERED]'},
+    })
+  })
+
+  it('returns NA_OPERATION_NAME when operationName is falsy', () => {
+    const req = {operationName: '', variables: {}, http: {headers: new Map()}}
+
+    const result = defaultRequestToMetaFormatter(req as any)
+
+    expect(result).toStrictEqual(expect.objectContaining({operationName: NA_OPERATION_NAME}))
+  })
+
+  it('returns NA_IP when no x-forwarded-for header is present', () => {
+    const req = {operationName: 'Test', variables: {}, http: {headers: new Map()}}
+
+    const result = defaultRequestToMetaFormatter(req as any)
+
+    expect(result).toStrictEqual(expect.objectContaining({clientIp: NA_IP}))
+  })
+
+  it('returns variables as undefined when req.variables is falsy', () => {
+    const req = {operationName: 'Test', variables: undefined, http: {headers: new Map()}}
+
+    const result = defaultRequestToMetaFormatter(req as any)
+
+    expect(result).toStrictEqual(expect.objectContaining({variables: undefined}))
+  })
+})
 
 describe('utils', () => {
   describe('filterSensitiveVariablesHelper', () => {

--- a/middleware/apollo-server-logging/src/defaults/responseToMetaFormatter.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/responseToMetaFormatter.test.ts
@@ -1,0 +1,13 @@
+import {defaultResponseToMetaFormatter} from './responseToMetaFormatter'
+
+describe('defaults', () => {
+  describe('defaultResponseToMetaFormatter', () => {
+    it('returns undefined regardless of input', () => {
+      expect(defaultResponseToMetaFormatter({})).toBeUndefined()
+    })
+
+    it('returns undefined for a response with data', () => {
+      expect(defaultResponseToMetaFormatter({data: {foo: 'bar'}})).toBeUndefined()
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/defaults/skipFunction.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/skipFunction.test.ts
@@ -1,0 +1,19 @@
+import {defaultSkipFunction} from './skipFunction'
+
+describe('defaults', () => {
+  describe('defaultSkipFunction', () => {
+    it('always returns false', () => {
+      expect(defaultSkipFunction({}, {}, {}, [])).toBe(false)
+    })
+
+    it('returns false regardless of arguments', () => {
+      expect(
+        defaultSkipFunction({operationName: 'Test'}, {data: {}}, {userId: 1}, [{message: 'err'}])
+      ).toBe(false)
+    })
+
+    it('returns false when called with no errors', () => {
+      expect(defaultSkipFunction({}, undefined, {})).toBe(false)
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/defaults/timestampAccessor.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/timestampAccessor.test.ts
@@ -1,0 +1,18 @@
+import {defaultTimestampAccessor} from './timestampAccessor'
+
+describe('defaults', () => {
+  describe('defaultTimestampAccessor', () => {
+    it('returns a number', () => {
+      expect(typeof defaultTimestampAccessor()).toBe('number')
+    })
+
+    it('returns a value based on performance.now()', () => {
+      const before = performance.now()
+      const result = defaultTimestampAccessor()
+      const after = performance.now()
+
+      expect(result).toBeGreaterThanOrEqual(before)
+      expect(result).toBeLessThanOrEqual(after)
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/defaults/timestampFormatter.test.ts
+++ b/middleware/apollo-server-logging/src/defaults/timestampFormatter.test.ts
@@ -1,0 +1,26 @@
+import {defaultTimestampFormatter} from './timestampFormatter'
+
+describe('defaults', () => {
+  describe('defaultTimestampFormatter', () => {
+    it('rounds to 4 decimal places', () => {
+      expect(defaultTimestampFormatter(1.23456789)).toEqual(1.2346)
+    })
+
+    it('handles whole numbers', () => {
+      expect(defaultTimestampFormatter(5)).toEqual(5)
+    })
+
+    it('handles zero', () => {
+      expect(defaultTimestampFormatter(0)).toEqual(0)
+    })
+
+    it('rounds correctly at the boundary', () => {
+      expect(defaultTimestampFormatter(1.00005)).toEqual(1.0001)
+      expect(defaultTimestampFormatter(1.00004)).toEqual(1)
+    })
+
+    it('handles large numbers', () => {
+      expect(defaultTimestampFormatter(123456.789012345)).toEqual(123456.789)
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/middleware.test.ts
+++ b/middleware/apollo-server-logging/src/middleware.test.ts
@@ -1,0 +1,242 @@
+import apolloServerLoggingMiddlewareFactory from './middleware'
+
+const createMockRequest = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  operationName: 'TestQuery',
+  variables: {},
+  http: {
+    headers: new Map(),
+  },
+  ...overrides,
+})
+
+const createMockResponse = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  data: {test: true},
+  ...overrides,
+})
+
+const invokePlugin = async (
+  config: Parameters<typeof apolloServerLoggingMiddlewareFactory>[0],
+  {
+    request = createMockRequest(),
+    response = createMockResponse(),
+    context = {},
+    errors,
+  }: {
+    request?: Record<string, unknown>
+    response?: Record<string, unknown>
+    context?: Record<string, unknown>
+    errors?: readonly unknown[]
+  } = {}
+): Promise<void> => {
+  const plugin = apolloServerLoggingMiddlewareFactory(config as any)
+  const listener = await plugin.requestDidStart!({request} as any)
+  await (listener as any).willSendResponse!({
+    request,
+    response,
+    context,
+    errors,
+  })
+}
+
+describe('apolloServerLoggingMiddlewareFactory', () => {
+  const testLogger = {log: jest.fn()}
+
+  afterEach(() => {
+    testLogger.log.mockClear()
+  })
+
+  it('returns a plugin with requestDidStart', () => {
+    const plugin = apolloServerLoggingMiddlewareFactory({
+      loggerAccessor: () => testLogger,
+    } as any)
+
+    expect(plugin.requestDidStart).toBeDefined()
+    expect(typeof plugin.requestDidStart).toBe('function')
+  })
+
+  it('logs a successful request through the full lifecycle', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger} as any)
+
+    expect(testLogger.log).toBeCalledWith(
+      expect.objectContaining({
+        level: 'info',
+        message: '-> GQL: processed TestQuery',
+        meta: expect.objectContaining({
+          duration: expect.any(Number),
+          req: expect.objectContaining({
+            operationName: 'TestQuery',
+          }),
+        }),
+      })
+    )
+  })
+
+  it('logs an error request with error level and error message', async () => {
+    const errors = [{message: 'Something broke', extensions: {code: 'INTERNAL_ERROR'}}]
+
+    await invokePlugin({loggerAccessor: () => testLogger} as any, {errors})
+
+    expect(testLogger.log).toBeCalledWith(
+      expect.objectContaining({
+        level: 'error',
+        message: '-X GQL: "INTERNAL_ERROR" error while processing TestQuery',
+      })
+    )
+  })
+
+  it('includes error meta in output', async () => {
+    const errors = [{message: 'fail', extensions: {code: 'BAD'}}]
+
+    await invokePlugin({loggerAccessor: () => testLogger} as any, {errors})
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.err).toBeDefined()
+    expect(logCall.meta.err).toHaveLength(1)
+    expect(logCall.meta.err[0]).toEqual(expect.objectContaining({message: 'fail'}))
+  })
+
+  it('uses level as a string override', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, level: 'warn'} as any)
+
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({level: 'warn'}))
+  })
+
+  it('uses level as a function', async () => {
+    const levelFn = jest.fn().mockReturnValue('debug')
+
+    await invokePlugin({loggerAccessor: () => testLogger, level: levelFn} as any)
+
+    expect(levelFn).toBeCalled()
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({level: 'debug'}))
+  })
+
+  it('includes baseMeta in output', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      baseMeta: {service: 'gql-api', version: '2.0'},
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.service).toBe('gql-api')
+    expect(logCall.meta.version).toBe('2.0')
+  })
+
+  it('uses custom metaField name', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, metaField: 'data'} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.data).toBeDefined()
+    expect(logCall.meta).toBeUndefined()
+  })
+
+  it('flattens meta to root when metaField is null', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, metaField: null} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta).toBeUndefined()
+    expect(logCall.duration).toBeDefined()
+    expect(logCall.req).toBeDefined()
+  })
+
+  it('uses custom reqField and resField names', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      reqField: 'request',
+      resField: 'response',
+      responseToMeta: () => ({status: 'ok'}),
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.request).toBeDefined()
+    expect(logCall.meta.response).toBeDefined()
+    expect(logCall.meta.req).toBeUndefined()
+    expect(logCall.meta.res).toBeUndefined()
+  })
+
+  it('uses custom errField name', async () => {
+    const errors = [{message: 'fail'}]
+
+    await invokePlugin({loggerAccessor: () => testLogger, errField: 'errors'} as any, {errors})
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.errors).toBeDefined()
+    expect(logCall.meta.err).toBeUndefined()
+  })
+
+  it('disables request meta when requestToMeta is false', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, requestToMeta: false} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.req).toBeUndefined()
+  })
+
+  it('disables response meta when responseToMeta is false', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      responseToMeta: false,
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.res).toBeUndefined()
+  })
+
+  it('disables context meta when contextToMeta is false', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, contextToMeta: false} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.ctx).toBeUndefined()
+  })
+
+  it('disables error meta when errorToMeta is false', async () => {
+    const errors = [{message: 'fail'}]
+
+    await invokePlugin({loggerAccessor: () => testLogger, errorToMeta: false} as any, {errors})
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.err).toBeUndefined()
+  })
+
+  it('includes contextToMeta data when provided', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      contextToMeta: () => ({userId: 'user-42'}),
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.ctx).toStrictEqual({userId: 'user-42'})
+  })
+
+  it('uses custom messageTemplate', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      messageTemplate: (req: any) => `Custom: ${req.operationName}`,
+    } as any)
+
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({message: 'Custom: TestQuery'}))
+  })
+
+  it('suppresses logging when messageTemplate returns undefined', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      messageTemplate: () => undefined,
+    } as any)
+
+    expect(testLogger.log).not.toBeCalled()
+  })
+
+  it('calculates duration using timestampAccessor and timestampFormatter', async () => {
+    let callCount = 0
+
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      timestampAccessor: () => {
+        callCount += 1
+        return callCount === 1 ? 100 : 150
+      },
+      timestampFormatter: (d: number) => d * 2,
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.duration).toBe(100) // (150 - 100) * 2
+  })
+})

--- a/middleware/apollo-server-logging/src/utils/formatter.test.ts
+++ b/middleware/apollo-server-logging/src/utils/formatter.test.ts
@@ -1,0 +1,49 @@
+import {mergeFormatters} from './formatter'
+
+describe('utils', () => {
+  describe('mergeFormatters', () => {
+    it('returns an empty object when given no formatters', () => {
+      const merged = mergeFormatters([])
+
+      expect(merged('input')).toStrictEqual({})
+    })
+
+    it('returns the result of a single formatter', () => {
+      const formatter = (val: string) => ({key: val})
+      const merged = mergeFormatters([formatter])
+
+      expect(merged('hello')).toStrictEqual({key: 'hello'})
+    })
+
+    it('merges the results of multiple formatters', () => {
+      const formatter1 = (val: string) => ({first: val})
+      const formatter2 = (val: string) => ({second: val.toUpperCase()})
+      const merged = mergeFormatters([formatter1, formatter2] as any)
+
+      expect(merged('hello')).toStrictEqual({first: 'hello', second: 'HELLO'})
+    })
+
+    it('later formatters override earlier ones for the same key', () => {
+      const formatter1 = () => ({key: 'first'})
+      const formatter2 = () => ({key: 'second'})
+      const merged = mergeFormatters([formatter1, formatter2])
+
+      expect(merged()).toStrictEqual({key: 'second'})
+    })
+
+    it('handles formatters that return undefined', () => {
+      const formatter1 = () => ({key: 'value'})
+      const formatter2 = () => undefined
+      const merged = mergeFormatters([formatter1, formatter2 as any])
+
+      expect(merged()).toStrictEqual({key: 'value'})
+    })
+
+    it('passes all arguments to each formatter', () => {
+      const formatter = (a: string, b: number) => ({a, b})
+      const merged = mergeFormatters([formatter])
+
+      expect(merged('test', 42)).toStrictEqual({a: 'test', b: 42})
+    })
+  })
+})

--- a/middleware/apollo-server-logging/src/utils/meta.test.ts
+++ b/middleware/apollo-server-logging/src/utils/meta.test.ts
@@ -28,6 +28,30 @@ describe('utils', () => {
 
       expect(rootMeta).toStrictEqual({foo: 'bar', subFoo: {subBar: true, bar: 'baz'}})
     })
+
+    it('assigns to root when propertyKey is null', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, null)
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
+
+    it('assigns to root when propertyKey is false', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, false)
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
+
+    it('assigns to root when propertyKey is empty string', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, '')
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
   })
 
   describe('assignArrayMeta', () => {
@@ -47,6 +71,14 @@ describe('utils', () => {
       assignArrayMeta(rootMeta, data, 'subFoo')
 
       expect(rootMeta).toStrictEqual({foo: 'bar', subFoo: [{subBar: true}, {bar: 'baz'}]})
+    })
+
+    it('overwrites existing non-array property', () => {
+      const meta: Record<string, unknown> = {field: 'not-an-array'}
+
+      assignArrayMeta(meta, [{new: true}], 'field')
+
+      expect(meta).toStrictEqual({field: [{new: true}]})
     })
   })
 })

--- a/middleware/apollo-server-logging/src/utils/type-guards.test.ts
+++ b/middleware/apollo-server-logging/src/utils/type-guards.test.ts
@@ -1,0 +1,49 @@
+import {isObj} from './type-guards'
+
+describe('utils', () => {
+  describe('isObj', () => {
+    it('returns true for a plain object', () => {
+      expect(isObj({foo: 'bar'})).toBe(true)
+    })
+
+    it('returns true for an empty object', () => {
+      expect(isObj({})).toBe(true)
+    })
+
+    it('returns false for null', () => {
+      expect(isObj(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isObj(undefined)).toBe(false)
+    })
+
+    it('returns false for an array', () => {
+      expect(isObj([1, 2, 3])).toBe(false)
+    })
+
+    it('returns false for an empty array', () => {
+      expect(isObj([])).toBe(false)
+    })
+
+    it('returns false for a string', () => {
+      expect(isObj('hello')).toBe(false)
+    })
+
+    it('returns false for a number', () => {
+      expect(isObj(42)).toBe(false)
+    })
+
+    it('returns false for a boolean', () => {
+      expect(isObj(true)).toBe(false)
+    })
+
+    it('returns true for a nested object', () => {
+      expect(isObj({a: {b: {c: 1}}})).toBe(true)
+    })
+
+    it('returns true for an object created with Object.create', () => {
+      expect(isObj(Object.create(null))).toBe(true)
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/defaults/contextToMetaFormatter.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/contextToMetaFormatter.test.ts
@@ -1,0 +1,13 @@
+import {defaultContextToMetaFormatter} from './contextToMetaFormatter'
+
+describe('defaults', () => {
+  describe('defaultContextToMetaFormatter', () => {
+    it('returns undefined regardless of input', () => {
+      expect(defaultContextToMetaFormatter({})).toBeUndefined()
+    })
+
+    it('returns undefined for a context with data', () => {
+      expect(defaultContextToMetaFormatter({user: 'test', role: 'admin'})).toBeUndefined()
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/defaults/errorMessageTemplate.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/errorMessageTemplate.test.ts
@@ -22,5 +22,27 @@ describe('defaults', () => {
         '-X GQL: "MY_ERROR_CODE" error while processing TestOp'
       )
     })
+
+    it('uses plural "errors" when multiple error codes are present', () => {
+      const mockReq = {operationName: 'TestOp'}
+
+      const err1 = new GraphQLError('err1', {extensions: {code: 'CODE_A'}})
+      const err2 = new GraphQLError('err2', {extensions: {code: 'CODE_B'}})
+
+      expect(defaultErrorMessageTemplate(mockReq, {}, {}, [err1, err2])).toEqual(
+        '-X GQL: "CODE_A", "CODE_B" errors while processing TestOp'
+      )
+    })
+
+    it('only includes errors that have codes', () => {
+      const mockReq = {operationName: 'TestOp'}
+
+      const err1 = new GraphQLError('err1', {extensions: {code: 'HAS_CODE'}})
+      const err2 = new GraphQLError('err2')
+
+      expect(defaultErrorMessageTemplate(mockReq, {}, {}, [err1, err2])).toEqual(
+        '-X GQL: "HAS_CODE" error while processing TestOp'
+      )
+    })
   })
 })

--- a/middleware/apollo-server-v4-logging/src/defaults/errorToMetaFormatter.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/errorToMetaFormatter.test.ts
@@ -1,0 +1,30 @@
+import {defaultErrorToMetaFormatter} from './errorToMetaFormatter'
+
+describe('defaults', () => {
+  describe('defaultErrorToMetaFormatter', () => {
+    it('returns a shallow copy of the error object', () => {
+      const err = {message: 'test-error', extensions: {code: 'MY_CODE'}}
+
+      const result = defaultErrorToMetaFormatter(err as any)
+
+      expect(result).toStrictEqual({message: 'test-error', extensions: {code: 'MY_CODE'}})
+    })
+
+    it('returns a new object (not the same reference)', () => {
+      const err = {message: 'test-error'}
+
+      const result = defaultErrorToMetaFormatter(err as any)
+
+      expect(result).not.toBe(err)
+      expect(result).toStrictEqual({message: 'test-error'})
+    })
+
+    it('handles an error with no extra properties', () => {
+      const err = {}
+
+      const result = defaultErrorToMetaFormatter(err as any)
+
+      expect(result).toStrictEqual({})
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/defaults/levelFunction.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/levelFunction.test.ts
@@ -1,0 +1,23 @@
+import {defaultLevelFunction} from './levelFunction'
+
+describe('defaults', () => {
+  describe('defaultLevelFunction', () => {
+    it('returns "info" when no errors are provided', () => {
+      expect(defaultLevelFunction({}, {}, {}, undefined)).toEqual('info')
+    })
+
+    it('returns "info" when errors array is empty', () => {
+      expect(defaultLevelFunction({}, {}, {}, [])).toEqual('info')
+    })
+
+    it('returns "error" when errors array has one error', () => {
+      expect(defaultLevelFunction({}, {}, {}, [{message: 'error'}])).toEqual('error')
+    })
+
+    it('returns "error" when errors array has multiple errors', () => {
+      expect(defaultLevelFunction({}, {}, {}, [{message: 'error1'}, {message: 'error2'}])).toEqual(
+        'error'
+      )
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/defaults/messageTemplate.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/messageTemplate.test.ts
@@ -1,0 +1,23 @@
+import {defaultMessageTemplate} from './messageTemplate'
+
+describe('defaults', () => {
+  describe('defaultMessageTemplate', () => {
+    it('correctly formats the message with operationName', () => {
+      const mockReq = {operationName: 'TestOp'}
+
+      expect(defaultMessageTemplate(mockReq, {}, {})).toEqual('-> GQL: processed TestOp')
+    })
+
+    it('handles undefined operationName', () => {
+      const mockReq = {operationName: undefined}
+
+      expect(defaultMessageTemplate(mockReq, {}, {})).toEqual('-> GQL: processed undefined')
+    })
+
+    it('handles null operationName', () => {
+      const mockReq = {operationName: null} as any
+
+      expect(defaultMessageTemplate(mockReq, {}, {})).toEqual('-> GQL: processed null')
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/defaults/requestToMetaFormatter.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/requestToMetaFormatter.test.ts
@@ -1,4 +1,75 @@
-import {filterSensitiveVariablesHelper} from './requestToMetaFormatter'
+import {NA_IP, NA_OPERATION_NAME} from '../constants'
+import {
+  filterSensitiveVariablesHelper,
+  getIpFromGraphQLRequest,
+  defaultRequestToMetaFormatter,
+} from './requestToMetaFormatter'
+
+describe('getIpFromGraphQLRequest', () => {
+  it('returns null when req.http is undefined', () => {
+    expect(getIpFromGraphQLRequest({} as any)).toBeNull()
+  })
+
+  it('returns null when x-forwarded-for header is absent', () => {
+    const req = {http: {headers: new Map()}}
+    expect(getIpFromGraphQLRequest(req as any)).toBeNull()
+  })
+
+  it('returns the first IP from a comma-separated x-forwarded-for', () => {
+    const headers = new Map([['x-forwarded-for', '10.0.0.1, 10.0.0.2']])
+    const req = {http: {headers}}
+    expect(getIpFromGraphQLRequest(req as any)).toBe('10.0.0.1')
+  })
+
+  it('returns a single IP from x-forwarded-for', () => {
+    const headers = new Map([['x-forwarded-for', '192.168.1.1']])
+    const req = {http: {headers}}
+    expect(getIpFromGraphQLRequest(req as any)).toBe('192.168.1.1')
+  })
+})
+
+describe('defaultRequestToMetaFormatter', () => {
+  it('returns operationName, clientIp, and filtered variables for a complete request', () => {
+    const headers = new Map([['x-forwarded-for', '1.2.3.4']])
+    const req = {
+      operationName: 'GetUser',
+      variables: {id: '123', password: 'secret'},
+      http: {headers},
+    }
+
+    const result = defaultRequestToMetaFormatter(req as any)
+
+    expect(result).toStrictEqual({
+      operationName: 'GetUser',
+      clientIp: '1.2.3.4',
+      variables: {id: '123', password: '[FILTERED]'},
+    })
+  })
+
+  it('returns NA_OPERATION_NAME when operationName is falsy', () => {
+    const req = {operationName: '', variables: {}, http: {headers: new Map()}}
+
+    const result = defaultRequestToMetaFormatter(req as any)
+
+    expect(result).toStrictEqual(expect.objectContaining({operationName: NA_OPERATION_NAME}))
+  })
+
+  it('returns NA_IP when no x-forwarded-for header is present', () => {
+    const req = {operationName: 'Test', variables: {}, http: {headers: new Map()}}
+
+    const result = defaultRequestToMetaFormatter(req as any)
+
+    expect(result).toStrictEqual(expect.objectContaining({clientIp: NA_IP}))
+  })
+
+  it('returns variables as undefined when req.variables is falsy', () => {
+    const req = {operationName: 'Test', variables: undefined, http: {headers: new Map()}}
+
+    const result = defaultRequestToMetaFormatter(req as any)
+
+    expect(result).toStrictEqual(expect.objectContaining({variables: undefined}))
+  })
+})
 
 describe('utils', () => {
   describe('filterSensitiveVariablesHelper', () => {

--- a/middleware/apollo-server-v4-logging/src/defaults/responseToMetaFormatter.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/responseToMetaFormatter.test.ts
@@ -1,0 +1,13 @@
+import {defaultResponseToMetaFormatter} from './responseToMetaFormatter'
+
+describe('defaults', () => {
+  describe('defaultResponseToMetaFormatter', () => {
+    it('returns undefined regardless of input', () => {
+      expect(defaultResponseToMetaFormatter({})).toBeUndefined()
+    })
+
+    it('returns undefined for a response with data', () => {
+      expect(defaultResponseToMetaFormatter({data: {foo: 'bar'}})).toBeUndefined()
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/defaults/skipFunction.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/skipFunction.test.ts
@@ -1,0 +1,19 @@
+import {defaultSkipFunction} from './skipFunction'
+
+describe('defaults', () => {
+  describe('defaultSkipFunction', () => {
+    it('always returns false', () => {
+      expect(defaultSkipFunction({}, {}, {}, [])).toBe(false)
+    })
+
+    it('returns false regardless of arguments', () => {
+      expect(defaultSkipFunction({operationName: 'TestOp'}, {data: {}}, {user: 'test'}, [])).toBe(
+        false
+      )
+    })
+
+    it('returns false when errors are provided', () => {
+      expect(defaultSkipFunction({}, undefined, {}, [{message: 'error'}])).toBe(false)
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/defaults/timestampAccessor.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/timestampAccessor.test.ts
@@ -1,0 +1,24 @@
+import {defaultTimestampAccessor} from './timestampAccessor'
+
+describe('defaults', () => {
+  describe('defaultTimestampAccessor', () => {
+    it('returns a number', () => {
+      const result = defaultTimestampAccessor()
+
+      expect(typeof result).toBe('number')
+    })
+
+    it('returns a value greater than or equal to zero', () => {
+      const result = defaultTimestampAccessor()
+
+      expect(result).toBeGreaterThanOrEqual(0)
+    })
+
+    it('returns increasing values on subsequent calls', () => {
+      const first = defaultTimestampAccessor()
+      const second = defaultTimestampAccessor()
+
+      expect(second).toBeGreaterThanOrEqual(first)
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/defaults/timestampFormatter.test.ts
+++ b/middleware/apollo-server-v4-logging/src/defaults/timestampFormatter.test.ts
@@ -1,0 +1,29 @@
+import {defaultTimestampFormatter} from './timestampFormatter'
+
+describe('defaults', () => {
+  describe('defaultTimestampFormatter', () => {
+    it('rounds to 4 decimal places', () => {
+      expect(defaultTimestampFormatter(1.123456789)).toEqual(1.1235)
+    })
+
+    it('handles whole numbers', () => {
+      expect(defaultTimestampFormatter(5)).toEqual(5)
+    })
+
+    it('handles zero', () => {
+      expect(defaultTimestampFormatter(0)).toEqual(0)
+    })
+
+    it('handles numbers with fewer than 4 decimal places', () => {
+      expect(defaultTimestampFormatter(1.12)).toEqual(1.12)
+    })
+
+    it('correctly rounds up', () => {
+      expect(defaultTimestampFormatter(1.00005)).toEqual(1.0001)
+    })
+
+    it('correctly rounds down', () => {
+      expect(defaultTimestampFormatter(1.00004)).toEqual(1)
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/middleware.test.ts
+++ b/middleware/apollo-server-v4-logging/src/middleware.test.ts
@@ -1,0 +1,239 @@
+import apolloServerLoggingMiddlewareFactory from './middleware'
+
+const createMockRequest = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  operationName: 'TestQuery',
+  variables: {},
+  http: {
+    headers: new Map(),
+  },
+  ...overrides,
+})
+
+const createMockResponse = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  data: {test: true},
+  ...overrides,
+})
+
+const invokePlugin = async (
+  config: Parameters<typeof apolloServerLoggingMiddlewareFactory>[0],
+  {
+    request = createMockRequest(),
+    response = createMockResponse(),
+    contextValue = {},
+    errors,
+  }: {
+    request?: Record<string, unknown>
+    response?: Record<string, unknown>
+    contextValue?: Record<string, unknown>
+    errors?: readonly unknown[]
+  } = {}
+): Promise<void> => {
+  const plugin = apolloServerLoggingMiddlewareFactory(config as any)
+  const listener = await plugin.requestDidStart!({request} as any)
+  await (listener as any).willSendResponse!({
+    request,
+    response,
+    contextValue,
+    errors,
+  })
+}
+
+describe('apolloServerLoggingMiddlewareFactory', () => {
+  const testLogger = {log: jest.fn()}
+
+  afterEach(() => {
+    testLogger.log.mockClear()
+  })
+
+  it('returns a plugin with requestDidStart', () => {
+    const plugin = apolloServerLoggingMiddlewareFactory({
+      loggerAccessor: () => testLogger,
+    } as any)
+
+    expect(plugin.requestDidStart).toBeDefined()
+    expect(typeof plugin.requestDidStart).toBe('function')
+  })
+
+  it('logs a successful request through the full lifecycle', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger} as any)
+
+    expect(testLogger.log).toBeCalledWith(
+      expect.objectContaining({
+        level: 'info',
+        message: '-> GQL: processed TestQuery',
+        meta: expect.objectContaining({
+          duration: expect.any(Number),
+          req: expect.objectContaining({
+            operationName: 'TestQuery',
+          }),
+        }),
+      })
+    )
+  })
+
+  it('logs an error request with error level and error message', async () => {
+    const errors = [{message: 'Something broke', extensions: {code: 'INTERNAL_ERROR'}}]
+
+    await invokePlugin({loggerAccessor: () => testLogger} as any, {errors})
+
+    expect(testLogger.log).toBeCalledWith(
+      expect.objectContaining({
+        level: 'error',
+        message: '-X GQL: "INTERNAL_ERROR" error while processing TestQuery',
+      })
+    )
+  })
+
+  it('includes error meta in output', async () => {
+    const errors = [{message: 'fail', extensions: {code: 'BAD'}}]
+
+    await invokePlugin({loggerAccessor: () => testLogger} as any, {errors})
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.err).toBeDefined()
+    expect(logCall.meta.err).toHaveLength(1)
+    expect(logCall.meta.err[0]).toEqual(expect.objectContaining({message: 'fail'}))
+  })
+
+  it('uses level as a string override', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, level: 'warn'} as any)
+
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({level: 'warn'}))
+  })
+
+  it('uses level as a function', async () => {
+    const levelFn = jest.fn().mockReturnValue('debug')
+
+    await invokePlugin({loggerAccessor: () => testLogger, level: levelFn} as any)
+
+    expect(levelFn).toBeCalled()
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({level: 'debug'}))
+  })
+
+  it('includes baseMeta in output', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      baseMeta: {service: 'gql-api', version: '2.0'},
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.service).toBe('gql-api')
+    expect(logCall.meta.version).toBe('2.0')
+  })
+
+  it('uses custom metaField name', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, metaField: 'data'} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.data).toBeDefined()
+    expect(logCall.meta).toBeUndefined()
+  })
+
+  it('flattens meta to root when metaField is null', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, metaField: null} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta).toBeUndefined()
+    expect(logCall.duration).toBeDefined()
+    expect(logCall.req).toBeDefined()
+  })
+
+  it('uses custom reqField and resField names', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      reqField: 'request',
+      resField: 'response',
+      responseToMeta: () => ({status: 'ok'}),
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.request).toBeDefined()
+    expect(logCall.meta.response).toBeDefined()
+    expect(logCall.meta.req).toBeUndefined()
+    expect(logCall.meta.res).toBeUndefined()
+  })
+
+  it('uses custom errField name', async () => {
+    const errors = [{message: 'fail'}]
+
+    await invokePlugin({loggerAccessor: () => testLogger, errField: 'errors'} as any, {errors})
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.errors).toBeDefined()
+    expect(logCall.meta.err).toBeUndefined()
+  })
+
+  it('disables request meta when requestToMeta is false', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, requestToMeta: false} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.req).toBeUndefined()
+  })
+
+  it('disables response meta when responseToMeta is false', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, responseToMeta: false} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.res).toBeUndefined()
+  })
+
+  it('disables context meta when contextToMeta is false', async () => {
+    await invokePlugin({loggerAccessor: () => testLogger, contextToMeta: false} as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.ctx).toBeUndefined()
+  })
+
+  it('disables error meta when errorToMeta is false', async () => {
+    const errors = [{message: 'fail'}]
+
+    await invokePlugin({loggerAccessor: () => testLogger, errorToMeta: false} as any, {errors})
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.err).toBeUndefined()
+  })
+
+  it('includes contextToMeta data when provided', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      contextToMeta: () => ({userId: 'user-42'}),
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.ctx).toStrictEqual({userId: 'user-42'})
+  })
+
+  it('uses custom messageTemplate', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      messageTemplate: (req: any) => `Custom: ${req.operationName}`,
+    } as any)
+
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({message: 'Custom: TestQuery'}))
+  })
+
+  it('suppresses logging when messageTemplate returns undefined', async () => {
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      messageTemplate: () => undefined,
+    } as any)
+
+    expect(testLogger.log).not.toBeCalled()
+  })
+
+  it('calculates duration using timestampAccessor and timestampFormatter', async () => {
+    let callCount = 0
+
+    await invokePlugin({
+      loggerAccessor: () => testLogger,
+      timestampAccessor: () => {
+        callCount += 1
+        return callCount === 1 ? 100 : 150
+      },
+      timestampFormatter: (d: number) => d * 2,
+    } as any)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.duration).toBe(100) // (150 - 100) * 2
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/utils/formatter.test.ts
+++ b/middleware/apollo-server-v4-logging/src/utils/formatter.test.ts
@@ -1,0 +1,50 @@
+import {mergeFormatters} from './formatter'
+
+describe('utils', () => {
+  describe('mergeFormatters', () => {
+    it('returns an empty object when given an empty array of formatters', () => {
+      const merged = mergeFormatters([])
+
+      expect(merged('input')).toStrictEqual({})
+    })
+
+    it('returns the result of a single formatter', () => {
+      const formatter = (val: string) => ({key: val})
+      const merged = mergeFormatters([formatter])
+
+      expect(merged('test')).toStrictEqual({key: 'test'})
+    })
+
+    it('merges results from multiple formatters', () => {
+      const formatter1 = (val: string) => ({first: val})
+      const formatter2 = (val: string) => ({second: val.toUpperCase()})
+      const merged = mergeFormatters([formatter1, formatter2] as any)
+
+      expect(merged('test')).toStrictEqual({first: 'test', second: 'TEST'})
+    })
+
+    it('later formatters overwrite earlier ones for the same key', () => {
+      const formatter1 = () => ({key: 'first'})
+      const formatter2 = () => ({key: 'second'})
+      const merged = mergeFormatters([formatter1, formatter2])
+
+      expect(merged()).toStrictEqual({key: 'second'})
+    })
+
+    it('handles formatters returning undefined by not adding properties', () => {
+      const formatter1 = () => ({key: 'value'})
+      const formatter2 = () => undefined as unknown as Record<string, unknown>
+      const merged = mergeFormatters([formatter1, formatter2])
+
+      expect(merged()).toStrictEqual({key: 'value'})
+    })
+
+    it('passes all arguments to each formatter', () => {
+      const formatter1 = (a: string, b: number) => ({combined: `${a}-${b}`})
+      const formatter2 = (a: string, b: number) => ({sum: `${a}+${b}`})
+      const merged = mergeFormatters([formatter1, formatter2] as any)
+
+      expect(merged('hello', 42)).toStrictEqual({combined: 'hello-42', sum: 'hello+42'})
+    })
+  })
+})

--- a/middleware/apollo-server-v4-logging/src/utils/meta.test.ts
+++ b/middleware/apollo-server-v4-logging/src/utils/meta.test.ts
@@ -28,6 +28,30 @@ describe('utils', () => {
 
       expect(rootMeta).toStrictEqual({foo: 'bar', subFoo: {subBar: true, bar: 'baz'}})
     })
+
+    it('assigns to root when propertyKey is null', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, null)
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
+
+    it('assigns to root when propertyKey is false', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, false)
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
+
+    it('assigns to root when propertyKey is empty string', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, '')
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
   })
 
   describe('assignArrayMeta', () => {
@@ -47,6 +71,14 @@ describe('utils', () => {
       assignArrayMeta(rootMeta, data, 'subFoo')
 
       expect(rootMeta).toStrictEqual({foo: 'bar', subFoo: [{subBar: true}, {bar: 'baz'}]})
+    })
+
+    it('overwrites existing non-array property', () => {
+      const meta: Record<string, unknown> = {field: 'not-an-array'}
+
+      assignArrayMeta(meta, [{new: true}], 'field')
+
+      expect(meta).toStrictEqual({field: [{new: true}]})
     })
   })
 })

--- a/middleware/apollo-server-v4-logging/src/utils/type-guards.test.ts
+++ b/middleware/apollo-server-v4-logging/src/utils/type-guards.test.ts
@@ -1,0 +1,42 @@
+import {isObj} from './type-guards'
+
+describe('utils', () => {
+  describe('isObj', () => {
+    it('returns true for a plain object', () => {
+      expect(isObj({})).toBe(true)
+    })
+
+    it('returns true for an object with properties', () => {
+      expect(isObj({foo: 'bar'})).toBe(true)
+    })
+
+    it('returns false for null', () => {
+      expect(isObj(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isObj(undefined)).toBe(false)
+    })
+
+    it('returns false for an array', () => {
+      expect(isObj([])).toBe(false)
+      expect(isObj([1, 2, 3])).toBe(false)
+    })
+
+    it('returns false for a string', () => {
+      expect(isObj('hello')).toBe(false)
+    })
+
+    it('returns false for a number', () => {
+      expect(isObj(42)).toBe(false)
+    })
+
+    it('returns false for a boolean', () => {
+      expect(isObj(true)).toBe(false)
+    })
+
+    it('returns true for a nested object', () => {
+      expect(isObj({nested: {deep: true}})).toBe(true)
+    })
+  })
+})

--- a/middleware/http-context-provider/src/__tests__/integration.test.ts
+++ b/middleware/http-context-provider/src/__tests__/integration.test.ts
@@ -31,7 +31,7 @@ describe('http-context-provider-middleware', () => {
     const serviceOne = (): void => {
       storeInHttpContext('service', 'one')
 
-      console.log(serviceTwo())
+      serviceTwo()
     }
 
     const serviceThree = (): unknown => getFromHttpContext('service')
@@ -43,5 +43,52 @@ describe('http-context-provider-middleware', () => {
     })
 
     await request(app).get('/test').expect(200).expect({foo: 'unknown'})
+  })
+
+  it('preserves context across async route handlers', async () => {
+    const app = express()
+    app.use(httpContextMiddleware)
+
+    app.use((req, res, next) => {
+      storeInHttpContext('userId', 'user-123')
+      next()
+    })
+
+    app.get('/test', async (req, res) => {
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, 10)
+      })
+      const userId = getFromHttpContext('userId')
+      res.json({userId})
+    })
+
+    await request(app).get('/test').expect(200).expect({userId: 'user-123'})
+  })
+
+  it('isolates context between concurrent requests', async () => {
+    const app = express()
+    app.use(httpContextMiddleware)
+
+    app.get('/test', async (req, res) => {
+      const id = req.query.id as string
+      storeInHttpContext('requestId', id)
+
+      // Stagger responses to ensure overlapping execution
+      const delay = id === '1' ? 50 : 10
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, delay)
+      })
+
+      const storedId = getFromHttpContext('requestId')
+      res.json({requestId: storedId})
+    })
+
+    const [res1, res2] = await Promise.all([
+      request(app).get('/test?id=1'),
+      request(app).get('/test?id=2'),
+    ])
+
+    expect(res1.body).toEqual({requestId: '1'})
+    expect(res2.body).toEqual({requestId: '2'})
   })
 })

--- a/middleware/http-context-provider/src/context.test.ts
+++ b/middleware/http-context-provider/src/context.test.ts
@@ -5,6 +5,7 @@ import {
   createChildContextStorage,
   setInContextStorage,
   getFromContextStorage,
+  hasInContextStorage,
 } from './context'
 
 describe('context', () => {
@@ -88,6 +89,126 @@ describe('context', () => {
       getContextStorage()?.set('foo', 'bar')
 
       expect(getContextStorage()?.get('foo')).toBe('bar')
+    })
+  })
+
+  test('createContextStorage forwards arguments to callback', () => {
+    const result = createContextStorage(
+      (a: number, b: string) => {
+        expect(a).toBe(42)
+        expect(b).toBe('hello')
+        return a + b.length
+      },
+      42,
+      'hello'
+    )
+
+    expect(result).toBe(47)
+  })
+
+  test('createContextStorage returns the callback return value', () => {
+    const result = createContextStorage(() => 'result-value')
+
+    expect(result).toBe('result-value')
+  })
+
+  test('createChildContextStorage forwards arguments to callback', () => {
+    createContextStorage(() => {
+      const result = createChildContextStorage(
+        (x: number, y: number) => {
+          expect(x).toBe(10)
+          expect(y).toBe(20)
+          return x + y
+        },
+        10,
+        20
+      )
+
+      expect(result).toBe(30)
+    })
+  })
+
+  test('createChildContextStorage called outside a context creates a fresh context', () => {
+    createChildContextStorage(() => {
+      expect(getContextStorage()).toBeDefined()
+      expect(getContextStorage()?.size).toBe(0)
+
+      setInContextStorage('key', 'value')
+      expect(getFromContextStorage('key')).toBe('value')
+    })
+  })
+
+  describe('hasInContextStorage', () => {
+    test('returns undefined when called outside a context', () => {
+      expect(hasInContextStorage('foo')).toBeUndefined()
+    })
+
+    test('returns false when key does not exist', () => {
+      createContextStorage(() => {
+        expect(hasInContextStorage('nonexistent')).toBe(false)
+      })
+    })
+
+    test('returns true when key exists', () => {
+      createContextStorage(() => {
+        setInContextStorage('foo', 'bar')
+        expect(hasInContextStorage('foo')).toBe(true)
+      })
+    })
+
+    test('returns true when key exists with undefined value', () => {
+      createContextStorage(() => {
+        setInContextStorage('foo', undefined)
+        expect(hasInContextStorage('foo')).toBe(true)
+      })
+    })
+
+    test('supports symbol keys', () => {
+      const key = Symbol('test')
+      createContextStorage(() => {
+        setInContextStorage(key, 'value')
+        expect(hasInContextStorage(key)).toBe(true)
+      })
+    })
+  })
+
+  describe('setInContextStorage', () => {
+    test('returns undefined when called outside a context', () => {
+      expect(setInContextStorage('foo', 'bar')).toBeUndefined()
+    })
+
+    test('stores a value that can be retrieved', () => {
+      createContextStorage(() => {
+        setInContextStorage('foo', 'bar')
+        expect(getFromContextStorage('foo')).toBe('bar')
+      })
+    })
+
+    test('supports symbol keys', () => {
+      const key = Symbol('test')
+      createContextStorage(() => {
+        setInContextStorage(key, 42)
+        expect(getFromContextStorage(key)).toBe(42)
+      })
+    })
+  })
+
+  describe('getFromContextStorage', () => {
+    test('returns undefined when called outside a context', () => {
+      expect(getFromContextStorage('foo')).toBeUndefined()
+    })
+
+    test('returns undefined for a missing key', () => {
+      createContextStorage(() => {
+        expect(getFromContextStorage('missing')).toBeUndefined()
+      })
+    })
+
+    test('returns stored value', () => {
+      createContextStorage(() => {
+        setInContextStorage('foo', 'bar')
+        expect(getFromContextStorage('foo')).toBe('bar')
+      })
     })
   })
 

--- a/middleware/http-context-provider/src/middleware.test.ts
+++ b/middleware/http-context-provider/src/middleware.test.ts
@@ -1,0 +1,126 @@
+import {createMocks} from 'node-mocks-http'
+import httpContextMiddleware from './middleware'
+import {getFromHttpContext, storeInHttpContext} from './read-write'
+import {getContextStorage} from './context'
+
+describe('httpContextMiddleware', () => {
+  test('calls next', done => {
+    const {req, res} = createMocks()
+
+    httpContextMiddleware(req, res, () => {
+      done()
+    })
+  })
+
+  test('initializes a context storage that is available in next', done => {
+    const {req, res} = createMocks()
+
+    httpContextMiddleware(req, res, () => {
+      expect(getContextStorage()).toBeDefined()
+      done()
+    })
+  })
+
+  test('context storage is empty when initialized', done => {
+    const {req, res} = createMocks()
+
+    httpContextMiddleware(req, res, () => {
+      expect(getContextStorage()?.size).toBe(0)
+      done()
+    })
+  })
+
+  test('allows storing and retrieving values within the middleware chain', done => {
+    const {req, res} = createMocks()
+
+    httpContextMiddleware(req, res, () => {
+      storeInHttpContext('requestId', '123')
+
+      expect(getFromHttpContext('requestId')).toBe('123')
+      done()
+    })
+  })
+
+  test('context is not available outside the middleware chain', done => {
+    const {req, res} = createMocks()
+
+    httpContextMiddleware(req, res, () => {
+      storeInHttpContext('foo', 'bar')
+      done()
+    })
+
+    expect(getFromHttpContext('foo')).toBeNull()
+  })
+
+  test('each request gets its own isolated context', done => {
+    const {req: req1, res: res1} = createMocks()
+    const {req: req2, res: res2} = createMocks()
+
+    let request1Done = false
+    let request2Done = false
+
+    const checkDone = (): void => {
+      if (request1Done && request2Done) {
+        done()
+      }
+    }
+
+    httpContextMiddleware(req1, res1, () => {
+      storeInHttpContext('source', 'request1')
+
+      expect(getFromHttpContext('source')).toBe('request1')
+      request1Done = true
+      checkDone()
+    })
+
+    httpContextMiddleware(req2, res2, () => {
+      storeInHttpContext('source', 'request2')
+
+      expect(getFromHttpContext('source')).toBe('request2')
+      request2Done = true
+      checkDone()
+    })
+  })
+
+  test('context persists across async operations', done => {
+    const {req, res} = createMocks()
+
+    httpContextMiddleware(req, res, async () => {
+      storeInHttpContext('before', 'async')
+
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, 10)
+      })
+
+      expect(getFromHttpContext('before')).toBe('async')
+      done()
+    })
+  })
+
+  test('supports storing symbol keys within the middleware context', done => {
+    const {req, res} = createMocks()
+    const key = Symbol('traceId')
+
+    httpContextMiddleware(req, res, () => {
+      storeInHttpContext(key, 'trace-abc')
+
+      expect(getFromHttpContext(key)).toBe('trace-abc')
+      done()
+    })
+  })
+
+  test('supports storing multiple values within the same request context', done => {
+    const {req, res} = createMocks()
+
+    httpContextMiddleware(req, res, () => {
+      storeInHttpContext('user', 'alice')
+      storeInHttpContext('role', 'admin')
+      storeInHttpContext('requestId', 'req-456')
+
+      expect(getFromHttpContext('user')).toBe('alice')
+      expect(getFromHttpContext('role')).toBe('admin')
+      expect(getFromHttpContext('requestId')).toBe('req-456')
+      done()
+    })
+  })
+})

--- a/middleware/http-context-provider/src/read-write.test.ts
+++ b/middleware/http-context-provider/src/read-write.test.ts
@@ -1,0 +1,142 @@
+import {createContextStorage} from './context'
+import {getFromHttpContext, storeInHttpContext} from './read-write'
+
+describe('read-write', () => {
+  describe('getFromHttpContext', () => {
+    test('returns null when called outside of a context', () => {
+      expect(getFromHttpContext('foo')).toBeNull()
+    })
+
+    test('returns null when key does not exist in context', () => {
+      createContextStorage(() => {
+        expect(getFromHttpContext('nonexistent')).toBeNull()
+      })
+    })
+
+    test('returns the value for an existing key', () => {
+      createContextStorage(() => {
+        storeInHttpContext('foo', 'bar')
+
+        expect(getFromHttpContext('foo')).toBe('bar')
+      })
+    })
+
+    test('returns the value when using a symbol key', () => {
+      const key = Symbol('myKey')
+
+      createContextStorage(() => {
+        storeInHttpContext(key, 42)
+
+        expect(getFromHttpContext(key)).toBe(42)
+      })
+    })
+
+    test('returns undefined (not null) when value was explicitly stored as undefined', () => {
+      createContextStorage(() => {
+        storeInHttpContext('key', undefined)
+
+        expect(getFromHttpContext('key')).toBeUndefined()
+      })
+    })
+
+    test('returns null (not undefined) when value was explicitly stored as null', () => {
+      createContextStorage(() => {
+        storeInHttpContext('key', null)
+
+        expect(getFromHttpContext('key')).toBeNull()
+      })
+    })
+
+    test('returns the most recently stored value for a key', () => {
+      createContextStorage(() => {
+        storeInHttpContext('foo', 'first')
+        storeInHttpContext('foo', 'second')
+
+        expect(getFromHttpContext('foo')).toBe('second')
+      })
+    })
+
+    test('can retrieve complex objects', () => {
+      const obj = {nested: {deeply: true}, list: [1, 2, 3]}
+
+      createContextStorage(() => {
+        storeInHttpContext('data', obj)
+
+        expect(getFromHttpContext('data')).toBe(obj)
+      })
+    })
+  })
+
+  describe('storeInHttpContext', () => {
+    test('returns null when called outside of a context', () => {
+      expect(storeInHttpContext('foo', 'bar')).toBeNull()
+    })
+
+    test('returns the stored value on success', () => {
+      createContextStorage(() => {
+        const result = storeInHttpContext('foo', 'bar')
+
+        expect(result).toBe('bar')
+      })
+    })
+
+    test('returns the stored value when using a symbol key', () => {
+      const key = Symbol('myKey')
+
+      createContextStorage(() => {
+        const result = storeInHttpContext(key, 'value')
+
+        expect(result).toBe('value')
+      })
+    })
+
+    test('overwrites a previously stored value', () => {
+      createContextStorage(() => {
+        storeInHttpContext('foo', 'original')
+        storeInHttpContext('foo', 'overwritten')
+
+        expect(getFromHttpContext('foo')).toBe('overwritten')
+      })
+    })
+
+    test('stores multiple independent keys', () => {
+      createContextStorage(() => {
+        storeInHttpContext('a', 1)
+        storeInHttpContext('b', 2)
+        storeInHttpContext('c', 3)
+
+        expect(getFromHttpContext('a')).toBe(1)
+        expect(getFromHttpContext('b')).toBe(2)
+        expect(getFromHttpContext('c')).toBe(3)
+      })
+    })
+  })
+
+  describe('context isolation', () => {
+    test('values are not shared between separate contexts', () => {
+      createContextStorage(() => {
+        storeInHttpContext('foo', 'context1')
+      })
+
+      createContextStorage(() => {
+        expect(getFromHttpContext('foo')).toBeNull()
+      })
+    })
+
+    test('values stored in one context are not visible in a sibling context', done => {
+      let context1Ready = false
+
+      createContextStorage(() => {
+        storeInHttpContext('shared', 'from-context-1')
+        context1Ready = true
+      })
+
+      expect(context1Ready).toBe(true)
+
+      createContextStorage(() => {
+        expect(getFromHttpContext('shared')).toBeNull()
+        done()
+      })
+    })
+  })
+})

--- a/middleware/logger-provider/src/index.test.ts
+++ b/middleware/logger-provider/src/index.test.ts
@@ -1,0 +1,139 @@
+import {createMocks} from 'node-mocks-http'
+
+import loggerProviderMiddlewareFactory from './index'
+
+const createMockLogger = () => {
+  const childLogger = {child: jest.fn()}
+  const logger = {child: jest.fn().mockReturnValue(childLogger)}
+  return {logger, childLogger}
+}
+
+describe('loggerProviderMiddlewareFactory', () => {
+  it('attaches the logger to req.logger when no childLoggerMeta is provided', () => {
+    const {logger} = createMockLogger()
+    const loggerProvider = loggerProviderMiddlewareFactory({logger} as any)
+
+    const {req, res} = createMocks()
+    const next = jest.fn()
+
+    loggerProvider(req, res, next)
+
+    expect(req.logger).toBe(logger)
+  })
+
+  it('calls next() after setting up the logger', () => {
+    const {logger} = createMockLogger()
+    const loggerProvider = loggerProviderMiddlewareFactory({logger} as any)
+
+    const {req, res} = createMocks()
+    const next = jest.fn()
+
+    loggerProvider(req, res, next)
+
+    expect(next).toBeCalled()
+  })
+
+  it('creates a child logger with meta when childLoggerMeta is provided', () => {
+    const {logger, childLogger} = createMockLogger()
+    const meta = {requestId: '123'}
+    const loggerProvider = loggerProviderMiddlewareFactory({
+      logger,
+      childLoggerMeta: () => meta,
+    } as any)
+
+    const {req, res} = createMocks()
+    const next = jest.fn()
+
+    loggerProvider(req, res, next)
+
+    expect(logger.child).toBeCalledWith(meta)
+    expect(req.logger).toBe(childLogger)
+  })
+
+  it('calls contextSetter with the child logger when childLoggerMeta is provided', () => {
+    const {logger, childLogger} = createMockLogger()
+    const contextSetter = jest.fn()
+    const loggerProvider = loggerProviderMiddlewareFactory({
+      logger,
+      contextSetter,
+      childLoggerMeta: () => ({requestId: '123'}),
+    } as any)
+
+    const {req, res} = createMocks()
+    const next = jest.fn()
+
+    loggerProvider(req, res, next)
+
+    expect(contextSetter).toBeCalledWith(childLogger)
+  })
+
+  it('calls contextSetter with the parent logger when no childLoggerMeta is provided', () => {
+    const {logger} = createMockLogger()
+    const contextSetter = jest.fn()
+    const loggerProvider = loggerProviderMiddlewareFactory({
+      logger,
+      contextSetter,
+    } as any)
+
+    const {req, res} = createMocks()
+    const next = jest.fn()
+
+    loggerProvider(req, res, next)
+
+    expect(contextSetter).toBeCalledWith(logger)
+  })
+
+  it('does not call logger.child when no childLoggerMeta is provided', () => {
+    const {logger} = createMockLogger()
+    const loggerProvider = loggerProviderMiddlewareFactory({logger} as any)
+
+    const {req, res} = createMocks()
+
+    loggerProvider(req, res, jest.fn())
+
+    expect(logger.child).not.toBeCalled()
+  })
+
+  it('creates independent child loggers for separate requests', () => {
+    const {logger} = createMockLogger()
+    const childLoggerMeta = jest.fn().mockReturnValue({requestId: '123'})
+    const loggerProvider = loggerProviderMiddlewareFactory({
+      logger,
+      childLoggerMeta,
+    } as any)
+
+    const {req: req1, res: res1} = createMocks()
+    const {req: req2, res: res2} = createMocks()
+
+    loggerProvider(req1, res1, jest.fn())
+    loggerProvider(req2, res2, jest.fn())
+
+    expect(logger.child).toBeCalledTimes(2)
+  })
+
+  it('does not call contextSetter when it is not provided', () => {
+    const {logger} = createMockLogger()
+    const loggerProvider = loggerProviderMiddlewareFactory({logger} as any)
+
+    const {req, res} = createMocks()
+    const next = jest.fn()
+
+    expect(() => loggerProvider(req, res, next)).not.toThrow()
+  })
+
+  it('passes the request object to childLoggerMeta callback', () => {
+    const {logger} = createMockLogger()
+    const childLoggerMeta = jest.fn().mockReturnValue({})
+    const loggerProvider = loggerProviderMiddlewareFactory({
+      logger,
+      childLoggerMeta,
+    } as any)
+
+    const {req, res} = createMocks()
+    const next = jest.fn()
+
+    loggerProvider(req, res, next)
+
+    expect(childLoggerMeta).toBeCalledWith(req)
+  })
+})

--- a/middleware/request-id-provider/src/index.test.ts
+++ b/middleware/request-id-provider/src/index.test.ts
@@ -1,4 +1,4 @@
-import {v4 as uuid} from 'uuid'
+import {v4 as uuid, validate} from 'uuid'
 import {createMocks} from 'node-mocks-http'
 
 import requestIdProviderMiddlewareFactory, {DEFAULT_REQUEST_ID_HEADER} from './index'
@@ -78,7 +78,7 @@ describe('requestIdProviderMiddlewareFactory', () => {
 
     const {req, res} = createMocks()
 
-    requestIdProvider(req, res, jest.fn)
+    requestIdProvider(req, res, jest.fn())
 
     expect(req.requestId).toBe('not-a-random-id')
   })
@@ -96,6 +96,148 @@ describe('requestIdProviderMiddlewareFactory', () => {
 
     expect(setViaCallback).toBeTruthy()
     expect(req.requestId).toBe(setViaCallback)
+  })
+
+  it('generates a valid uuid v4 by default', () => {
+    const requestIdProvider = requestIdProviderMiddlewareFactory()
+
+    const {req, res} = createMocks()
+
+    requestIdProvider(req, res, jest.fn())
+
+    expect(validate(req.requestId)).toBe(true)
+  })
+
+  describe('addToReqHeaders', () => {
+    it('adds requestId to request headers by default', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory()
+
+      const {req, res} = createMocks()
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(req.headers[DEFAULT_REQUEST_ID_HEADER]).toBe(req.requestId)
+    })
+
+    it('does not add requestId to request headers when addToReqHeaders is false', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory({
+        addToReqHeaders: false,
+      })
+
+      const {req, res} = createMocks()
+      const originalHeaders = {...req.headers}
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(req.headers[DEFAULT_REQUEST_ID_HEADER]).toBe(
+        originalHeaders[DEFAULT_REQUEST_ID_HEADER]
+      )
+    })
+
+    it('uses the custom header name for request headers', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory({
+        requestIdHeaderName: 'x-correlation-id',
+      })
+
+      const {req, res} = createMocks()
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(req.headers['x-correlation-id']).toBe(req.requestId)
+    })
+  })
+
+  describe('addToResHeaders', () => {
+    it('adds requestId to response headers by default', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory()
+
+      const {req, res} = createMocks()
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(res.getHeader(DEFAULT_REQUEST_ID_HEADER)).toBe(req.requestId)
+    })
+
+    it('does not add requestId to response headers when addToResHeaders is false', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory({
+        addToResHeaders: false,
+      })
+
+      const {req, res} = createMocks()
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(res.getHeader(DEFAULT_REQUEST_ID_HEADER)).toBeUndefined()
+    })
+
+    it('uses the custom header name for response headers', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory({
+        requestIdHeaderName: 'x-correlation-id',
+      })
+
+      const {req, res} = createMocks()
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(res.getHeader('x-correlation-id')).toBe(req.requestId)
+    })
+  })
+
+  describe('requestIdFilter', () => {
+    it('applies a custom filter to incoming request ids', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory({
+        readFromRequest: true,
+        requestIdFilter: id => (id.startsWith('valid-') ? id : undefined),
+      })
+
+      const {req, res} = createMocks({headers: {[DEFAULT_REQUEST_ID_HEADER]: 'valid-123'}})
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(req.requestId).toBe('valid-123')
+    })
+
+    it('falls through to generator when custom filter rejects the id', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory({
+        readFromRequest: true,
+        requestIdFilter: id => (id.startsWith('valid-') ? id : undefined),
+      })
+
+      const {req, res} = createMocks({headers: {[DEFAULT_REQUEST_ID_HEADER]: 'invalid-123'}})
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(req.requestId).not.toBe('invalid-123')
+      expect(validate(req.requestId)).toBe(true)
+    })
+  })
+
+  describe('readFromRequest edge cases', () => {
+    it('generates a new id when readFromRequest is true but header is missing', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory({
+        readFromRequest: true,
+      })
+
+      const {req, res} = createMocks()
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(req.requestId).toBeTruthy()
+      expect(validate(req.requestId)).toBe(true)
+    })
+
+    it('generates a new id when readFromRequest is true and header is empty string', () => {
+      const requestIdProvider = requestIdProviderMiddlewareFactory({
+        readFromRequest: true,
+        requestIdFilter: undefined,
+      })
+
+      const {req, res} = createMocks({headers: {[DEFAULT_REQUEST_ID_HEADER]: ''}})
+
+      requestIdProvider(req, res, jest.fn())
+
+      expect(req.requestId).toBeTruthy()
+    })
   })
 
   describe('bad input', () => {

--- a/middleware/request-logging/src/__tests__/performance.test.ts
+++ b/middleware/request-logging/src/__tests__/performance.test.ts
@@ -25,8 +25,6 @@ describe('requestLoggingMiddlewareFactory performance', () => {
     )(async app => {
       const res = await measureFunctionPerformance(() => request(app).get('/ping'))
 
-      console.log({res, baseLine})
-
       // max 30% less requests
       expect(res.count).toBeGreaterThanOrEqual(baseLine.count * 0.3)
 

--- a/middleware/request-logging/src/__tests__/utils.ts
+++ b/middleware/request-logging/src/__tests__/utils.ts
@@ -63,7 +63,7 @@ const getPercentiles = (buckets: number[], durations: number[]): Record<number, 
 const getPerformanceObserver = (
   options:
     | {
-        entryTypes: ReadonlyArray<EntryType>
+        entryTypes: EntryType[]
         buffered?: boolean | undefined
       }
     | {
@@ -75,7 +75,7 @@ const getPerformanceObserver = (
   const observer = new PerformanceObserver(list => {
     perfEntries.push(...list.getEntries())
   })
-  observer.observe(options)
+  observer.observe(options as any)
 
   return {
     observer,

--- a/middleware/request-logging/src/defaults/contextToMetaFormatter.test.ts
+++ b/middleware/request-logging/src/defaults/contextToMetaFormatter.test.ts
@@ -1,0 +1,13 @@
+import {createMocks} from 'node-mocks-http'
+
+import {defaultContextToMetaFormatter} from './contextToMetaFormatter'
+
+describe('defaults', () => {
+  describe('defaultContextToMetaFormatter', () => {
+    it('returns undefined', () => {
+      const {req, res} = createMocks()
+
+      expect(defaultContextToMetaFormatter(req, res)).toBeUndefined()
+    })
+  })
+})

--- a/middleware/request-logging/src/defaults/levelFunction.test.ts
+++ b/middleware/request-logging/src/defaults/levelFunction.test.ts
@@ -1,0 +1,9 @@
+import {defaultLevelFunction} from './levelFunction'
+
+describe('defaults', () => {
+  describe('defaultLevelFunction', () => {
+    it('is the string "info"', () => {
+      expect(defaultLevelFunction).toBe('info')
+    })
+  })
+})

--- a/middleware/request-logging/src/defaults/messageTemplate.test.ts
+++ b/middleware/request-logging/src/defaults/messageTemplate.test.ts
@@ -1,0 +1,25 @@
+import {createRequest} from 'node-mocks-http'
+
+import {defaultMessageTemplate} from './messageTemplate'
+
+describe('defaults', () => {
+  describe('defaultMessageTemplate', () => {
+    it('returns a message with the HTTP method and URL', () => {
+      const req = createRequest({method: 'GET', url: '/health'})
+
+      expect(defaultMessageTemplate(req)).toBe('HTTP GET /health')
+    })
+
+    it('handles POST requests', () => {
+      const req = createRequest({method: 'POST', url: '/api/users'})
+
+      expect(defaultMessageTemplate(req)).toBe('HTTP POST /api/users')
+    })
+
+    it('includes query string in the URL', () => {
+      const req = createRequest({method: 'GET', url: '/search?q=test'})
+
+      expect(defaultMessageTemplate(req)).toBe('HTTP GET /search?q=test')
+    })
+  })
+})

--- a/middleware/request-logging/src/defaults/responseToMetaFormatter.test.ts
+++ b/middleware/request-logging/src/defaults/responseToMetaFormatter.test.ts
@@ -1,0 +1,33 @@
+import {createResponse} from 'node-mocks-http'
+
+import {defaultResponseToMetaFormatter} from './responseToMetaFormatter'
+
+describe('defaults', () => {
+  describe('defaultResponseToMetaFormatter', () => {
+    it('returns the status code from the response', () => {
+      const res = createResponse()
+
+      expect(defaultResponseToMetaFormatter(res)).toStrictEqual({
+        statusCode: 200,
+      })
+    })
+
+    it('returns a non-200 status code', () => {
+      const res = createResponse()
+      res.statusCode = 404
+
+      expect(defaultResponseToMetaFormatter(res)).toStrictEqual({
+        statusCode: 404,
+      })
+    })
+
+    it('returns a 500 status code', () => {
+      const res = createResponse()
+      res.statusCode = 500
+
+      expect(defaultResponseToMetaFormatter(res)).toStrictEqual({
+        statusCode: 500,
+      })
+    })
+  })
+})

--- a/middleware/request-logging/src/defaults/skipFunction.test.ts
+++ b/middleware/request-logging/src/defaults/skipFunction.test.ts
@@ -1,0 +1,23 @@
+import {createMocks} from 'node-mocks-http'
+
+import {defaultSkipFunction} from './skipFunction'
+
+describe('defaults', () => {
+  describe('defaultSkipFunction', () => {
+    it('always returns false', () => {
+      const {req, res} = createMocks()
+
+      expect(defaultSkipFunction(req, res)).toBe(false)
+    })
+
+    it('returns false regardless of request method or status code', () => {
+      const {req, res} = createMocks({
+        method: 'POST',
+        url: '/some-path',
+      })
+      res.statusCode = 500
+
+      expect(defaultSkipFunction(req, res)).toBe(false)
+    })
+  })
+})

--- a/middleware/request-logging/src/defaults/timestampAccessor.test.ts
+++ b/middleware/request-logging/src/defaults/timestampAccessor.test.ts
@@ -1,0 +1,18 @@
+import {defaultTimestampAccessor} from './timestampAccessor'
+
+describe('defaults', () => {
+  describe('defaultTimestampAccessor', () => {
+    it('returns a number', () => {
+      const result = defaultTimestampAccessor()
+
+      expect(typeof result).toBe('number')
+    })
+
+    it('returns increasing values on subsequent calls', () => {
+      const first = defaultTimestampAccessor()
+      const second = defaultTimestampAccessor()
+
+      expect(second).toBeGreaterThanOrEqual(first)
+    })
+  })
+})

--- a/middleware/request-logging/src/middleware-factory.test.ts
+++ b/middleware/request-logging/src/middleware-factory.test.ts
@@ -1,7 +1,6 @@
 import request from 'supertest'
 import express from 'express'
 import type {NextHandleFunction} from 'connect'
-// import type {Server} from 'node:http'
 import requestLoggingMiddlewareFactory from './middleware-factory'
 
 const getSimpleApp = (middleware?: NextHandleFunction): express.Express => {
@@ -13,22 +12,6 @@ const getSimpleApp = (middleware?: NextHandleFunction): express.Express => {
 
   return app
 }
-
-// const withSimpleApp =
-//   (middleware?: NextHandleFunction) =>
-//   async (callback: (app: express.Express) => void | Promise<void>): Promise<void> => {
-//     const app = getSimpleApp(middleware)
-//
-//     const server = await new Promise<Server>(resolve => {
-//       const s = app.listen(9987, () => {
-//         resolve(s)
-//       })
-//     })
-//
-//     await callback(app)
-//
-//     server.close()
-//   }
 
 describe('requestLoggingMiddlewareFactory', () => {
   const testLogger = {log: jest.fn()}
@@ -119,5 +102,158 @@ describe('requestLoggingMiddlewareFactory', () => {
         statusCode: 200,
       },
     })
+  })
+
+  it('uses on-finished hook when configured', async () => {
+    const app = getSimpleApp(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        hook: 'on-finished',
+      })
+    )
+
+    await request(app).get('/ping').expect(200)
+
+    expect(testLogger.log).toBeCalledWith(
+      expect.objectContaining({
+        level: 'info',
+        message: 'HTTP GET /ping',
+      })
+    )
+  })
+
+  it('uses level as a function to determine log level', async () => {
+    const app = express()
+    app.use(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        level: (_req, res) => (res.statusCode >= 500 ? 'error' : 'info'),
+      })
+    )
+    app.get('/ok', (_req, res) => res.status(200).json({}))
+    app.get('/fail', (_req, res) => res.status(500).json({}))
+
+    await request(app).get('/ok').expect(200)
+
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({level: 'info'}))
+
+    testLogger.log.mockClear()
+
+    await request(app).get('/fail').expect(500)
+
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({level: 'error'}))
+  })
+
+  it('includes baseMeta in log output', async () => {
+    const app = getSimpleApp(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        baseMeta: {service: 'test-service', version: '1.0.0'},
+      })
+    )
+
+    await request(app).get('/ping').expect(200)
+
+    expect(testLogger.log).toBeCalledWith(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          service: 'test-service',
+          version: '1.0.0',
+        }),
+      })
+    )
+  })
+
+  it('uses custom reqField and resField names', async () => {
+    const app = getSimpleApp(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        reqField: 'request',
+        resField: 'response',
+      })
+    )
+
+    await request(app).get('/ping').expect(200)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.request).toBeDefined()
+    expect(logCall.meta.response).toBeDefined()
+    expect(logCall.meta.req).toBeUndefined()
+    expect(logCall.meta.res).toBeUndefined()
+  })
+
+  it('flattens req/res meta to root when field is null', async () => {
+    const app = getSimpleApp(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        metaField: null,
+        reqField: null,
+        resField: null,
+      })
+    )
+
+    await request(app).get('/ping').expect(200)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.method).toBe('GET')
+    expect(logCall.statusCode).toBe(200)
+    expect(logCall.url).toBe('/ping')
+  })
+
+  it('accepts requestToMeta as an array of formatters', async () => {
+    const app = getSimpleApp(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        requestToMeta: [req => ({method: req.method}), req => ({url: req.url})],
+      })
+    )
+
+    await request(app).get('/ping').expect(200)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.req).toStrictEqual({method: 'GET', url: '/ping'})
+  })
+
+  it('includes contextToMeta data when provided', async () => {
+    const app = getSimpleApp(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        contextToMeta: () => ({traceId: 'abc-123'}),
+      })
+    )
+
+    await request(app).get('/ping').expect(200)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.ctx).toStrictEqual({traceId: 'abc-123'})
+  })
+
+  it('uses custom ctxField name', async () => {
+    const app = getSimpleApp(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        contextToMeta: () => ({traceId: 'abc-123'}),
+        ctxField: 'context',
+      })
+    )
+
+    await request(app).get('/ping').expect(200)
+
+    const logCall = testLogger.log.mock.calls[0][0]
+    expect(logCall.meta.context).toStrictEqual({traceId: 'abc-123'})
+    expect(logCall.meta.ctx).toBeUndefined()
+  })
+
+  it('uses a custom messageTemplate', async () => {
+    const app = getSimpleApp(
+      requestLoggingMiddlewareFactory({
+        loggerAccessor: () => testLogger,
+        messageTemplate: (req: any, res: any) => `${req.method} ${req.url} -> ${res.statusCode}`,
+      })
+    )
+
+    await request(app).get('/ping').expect(200)
+
+    expect(testLogger.log).toBeCalledWith(expect.objectContaining({message: 'GET /ping -> 200'}))
   })
 })

--- a/middleware/request-logging/src/utils/express.test.ts
+++ b/middleware/request-logging/src/utils/express.test.ts
@@ -1,0 +1,76 @@
+import {createRequest} from 'node-mocks-http'
+import {IncomingMessage} from 'node:http'
+import {Socket} from 'node:net'
+import {hasOriginalUrl, getIpFromExpressRequest} from './express'
+
+describe('utils', () => {
+  describe('hasOriginalUrl', () => {
+    it('returns true for an express request with originalUrl', () => {
+      const req = createRequest({url: '/test'})
+      expect(hasOriginalUrl(req)).toBe(true)
+    })
+
+    it('returns false for a plain IncomingMessage without originalUrl', () => {
+      const req = new IncomingMessage(new Socket())
+      expect(hasOriginalUrl(req)).toBe(false)
+    })
+
+    it('returns false for a plain object without originalUrl', () => {
+      expect(hasOriginalUrl({url: '/test'})).toBe(false)
+    })
+
+    it('returns true for a plain object with originalUrl', () => {
+      expect(hasOriginalUrl({originalUrl: '/test'})).toBe(true)
+    })
+
+    it('returns true when originalUrl is an empty string', () => {
+      expect(hasOriginalUrl({originalUrl: ''})).toBe(true)
+    })
+  })
+
+  describe('getIpFromExpressRequest', () => {
+    it('returns req.ip if available', () => {
+      const req = createRequest({ip: '192.168.1.1'})
+      expect(getIpFromExpressRequest(req)).toBe('192.168.1.1')
+    })
+
+    it('returns the first x-forwarded-for ip when req.ip is falsy and header function exists', () => {
+      const req = createRequest({
+        headers: {'x-forwarded-for': '10.0.0.1, 10.0.0.2'},
+      })
+      // Override ip to be falsy so it falls through to header check
+      Object.defineProperty(req, 'ip', {value: '', writable: true})
+      expect(getIpFromExpressRequest(req)).toBe('10.0.0.1')
+    })
+
+    it('returns a single x-forwarded-for ip correctly', () => {
+      const req = createRequest({
+        headers: {'x-forwarded-for': '10.0.0.1'},
+      })
+      Object.defineProperty(req, 'ip', {value: '', writable: true})
+      expect(getIpFromExpressRequest(req)).toBe('10.0.0.1')
+    })
+
+    it('falls back to socket.remoteAddress when header function exists but x-forwarded-for is absent', () => {
+      const req = createRequest()
+      Object.defineProperty(req, 'ip', {value: '', writable: true})
+      req.socket = {remoteAddress: '172.16.0.1'} as any
+      expect(getIpFromExpressRequest(req)).toBe('172.16.0.1')
+    })
+
+    it('returns socket.remoteAddress when req has no header function', () => {
+      const req = {socket: {remoteAddress: '127.0.0.1'}} as any
+      expect(getIpFromExpressRequest(req)).toBe('127.0.0.1')
+    })
+
+    it('returns null when no ip source is available', () => {
+      const req = {socket: {}} as any
+      expect(getIpFromExpressRequest(req)).toBeNull()
+    })
+
+    it('returns null when there is no socket at all', () => {
+      const req = {} as any
+      expect(getIpFromExpressRequest(req)).toBeNull()
+    })
+  })
+})

--- a/middleware/request-logging/src/utils/meta.test.ts
+++ b/middleware/request-logging/src/utils/meta.test.ts
@@ -28,5 +28,37 @@ describe('utils', () => {
 
       expect(rootMeta).toStrictEqual({foo: 'bar', subFoo: {subBar: true, bar: 'baz'}})
     })
+
+    it('assigns to root when propertyKey is null', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, null)
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
+
+    it('assigns to root when propertyKey is false', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, false as any)
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
+
+    it('assigns to root when propertyKey is empty string', () => {
+      const meta: Record<string, unknown> = {existing: true}
+
+      assignMeta(meta, {added: 'value'}, '')
+
+      expect(meta).toStrictEqual({existing: true, added: 'value'})
+    })
+
+    it('overwrites existing non-object property with the given key', () => {
+      const meta: Record<string, unknown> = {field: 'string-value'}
+
+      assignMeta(meta, {nested: true}, 'field')
+
+      expect(meta).toStrictEqual({field: {nested: true}})
+    })
   })
 })

--- a/middleware/request-logging/src/utils/misc.test.ts
+++ b/middleware/request-logging/src/utils/misc.test.ts
@@ -1,5 +1,6 @@
 import {createRequest, createResponse} from 'node-mocks-http'
-import {mergeFormatters} from './misc'
+import {mergeFormatters, formatTimestamp, filterSensitiveVariablesHelper} from './misc'
+import {FILTERED_INDICATOR} from '../constants'
 import {RequestToMetaFormatter, ResponseToMetaFormatter} from '../defaults'
 
 describe('utils', () => {
@@ -18,6 +19,29 @@ describe('utils', () => {
       })
     })
 
+    it('later formatters override earlier keys', () => {
+      const f1 = (): Record<string, unknown> => ({key: 'first', other: 'kept'})
+      const f2 = (): Record<string, unknown> => ({key: 'second'})
+
+      const formatter = mergeFormatters([f1, f2])
+
+      expect(formatter()).toStrictEqual({key: 'second', other: 'kept'})
+    })
+
+    it('returns an empty object for an empty array', () => {
+      const formatter = mergeFormatters([])
+
+      expect(formatter()).toStrictEqual({})
+    })
+
+    it('works with a single formatter', () => {
+      const f1 = (): Record<string, unknown> => ({only: 'one'})
+
+      const formatter = mergeFormatters([f1])
+
+      expect(formatter()).toStrictEqual({only: 'one'})
+    })
+
     it('can merge ResponseToMeta formatters', () => {
       const f1: ResponseToMetaFormatter<any> = res => ({statusCode: res.statusCode})
       const f2: ResponseToMetaFormatter<any> = res => ({statusMessage: res.statusMessage})
@@ -29,6 +53,94 @@ describe('utils', () => {
       expect(formatter(testResponse)).toStrictEqual({
         statusCode: 200,
         statusMessage: 'OK',
+      })
+    })
+  })
+
+  describe('formatTimestamp', () => {
+    it('rounds a timestamp to 4 decimal places', () => {
+      expect(formatTimestamp(1.23456789)).toBe(1.2346)
+    })
+
+    it('returns the same value if it has fewer than 4 decimals', () => {
+      expect(formatTimestamp(1.23)).toBe(1.23)
+    })
+
+    it('handles zero', () => {
+      expect(formatTimestamp(0)).toBe(0)
+    })
+
+    it('handles whole numbers', () => {
+      expect(formatTimestamp(5)).toBe(5)
+    })
+
+    it('handles very small numbers', () => {
+      expect(formatTimestamp(0.00001)).toBe(0)
+    })
+  })
+
+  describe('filterSensitiveVariablesHelper', () => {
+    it('filters a sensitive variable', () => {
+      const result = filterSensitiveVariablesHelper({username: 'john', password: 'secret123'}, [
+        'password',
+      ])
+      expect(result).toStrictEqual({
+        username: 'john',
+        password: FILTERED_INDICATOR,
+      })
+    })
+
+    it('does not filter non-sensitive variables', () => {
+      const result = filterSensitiveVariablesHelper({username: 'john', email: 'john@example.com'}, [
+        'password',
+      ])
+      expect(result).toStrictEqual({
+        username: 'john',
+        email: 'john@example.com',
+      })
+    })
+
+    it('filters multiple sensitive variables', () => {
+      const result = filterSensitiveVariablesHelper(
+        {username: 'john', password: 'secret', token: 'abc123'},
+        ['password', 'token']
+      )
+      expect(result).toStrictEqual({
+        username: 'john',
+        password: FILTERED_INDICATOR,
+        token: FILTERED_INDICATOR,
+      })
+    })
+
+    it('recursively filters nested objects', () => {
+      const result = filterSensitiveVariablesHelper({user: {name: 'john', password: 'secret'}}, [
+        'password',
+      ])
+      expect(result).toStrictEqual({
+        user: {name: 'john', password: FILTERED_INDICATOR},
+      })
+    })
+
+    it('handles empty variables object', () => {
+      const result = filterSensitiveVariablesHelper({}, ['password'])
+      expect(result).toStrictEqual({})
+    })
+
+    it('handles empty sensitive list', () => {
+      const result = filterSensitiveVariablesHelper({username: 'john', password: 'secret'}, [])
+      expect(result).toStrictEqual({
+        username: 'john',
+        password: 'secret',
+      })
+    })
+
+    it('handles deeply nested objects', () => {
+      const result = filterSensitiveVariablesHelper(
+        {level1: {level2: {secret: 'hidden', safe: 'visible'}}},
+        ['secret']
+      )
+      expect(result).toStrictEqual({
+        level1: {level2: {secret: FILTERED_INDICATOR, safe: 'visible'}},
       })
     })
   })

--- a/middleware/request-logging/src/utils/type-guards.test.ts
+++ b/middleware/request-logging/src/utils/type-guards.test.ts
@@ -1,0 +1,53 @@
+import {isObj} from './type-guards'
+
+describe('utils', () => {
+  describe('isObj', () => {
+    it('returns true for a plain object', () => {
+      expect(isObj({foo: 'bar'})).toBe(true)
+    })
+
+    it('returns true for an empty object', () => {
+      expect(isObj({})).toBe(true)
+    })
+
+    it('returns false for null', () => {
+      expect(isObj(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isObj(undefined)).toBe(false)
+    })
+
+    it('returns false for an array', () => {
+      expect(isObj([1, 2, 3])).toBe(false)
+    })
+
+    it('returns false for an empty array', () => {
+      expect(isObj([])).toBe(false)
+    })
+
+    it('returns false for a string', () => {
+      expect(isObj('hello')).toBe(false)
+    })
+
+    it('returns false for a number', () => {
+      expect(isObj(42)).toBe(false)
+    })
+
+    it('returns false for a boolean', () => {
+      expect(isObj(true)).toBe(false)
+    })
+
+    it('returns true for a nested object', () => {
+      expect(isObj({a: {b: {c: 1}}})).toBe(true)
+    })
+
+    it('returns true for an object created with Object.create(null)', () => {
+      expect(isObj(Object.create(null))).toBe(true)
+    })
+
+    it('returns false for a function', () => {
+      expect(isObj(() => {})).toBe(false)
+    })
+  })
+})

--- a/packages/logger/src/__tests__/logger-regression.test.ts
+++ b/packages/logger/src/__tests__/logger-regression.test.ts
@@ -292,5 +292,52 @@ describe('logger output', () => {
         },
       ])
     })
+
+    it('serializes error with cause chain', () => {
+      const cause = new Error('root cause')
+      const error = new Error('outer error', {cause})
+
+      logger.error('chained', {error})
+
+      expect(testStream).toHaveLogged([
+        {
+          level: 'error',
+          timestamp: '2023-08-02T19:19:49.795Z',
+          message: 'chained',
+          error: expect.objectContaining({
+            message: 'outer error',
+            type: 'Error',
+            cause: expect.objectContaining({
+              message: 'root cause',
+              type: 'Error',
+            }),
+          }),
+        },
+      ])
+    })
+  })
+
+  describe('log() with string level', () => {
+    const testStream = createTestOutput()
+    const logger = loggerFactory({
+      silent: true,
+      testOutputStream: testStream,
+    })
+
+    beforeEach(() => {
+      testStream.clear()
+    })
+
+    it('logs via log(level, message) with a string level', () => {
+      logger.log('warn', 'string level message')
+
+      expect(testStream).toHaveLogged([
+        {
+          level: 'warn',
+          timestamp: '2023-08-02T19:19:49.795Z',
+          message: 'string level message',
+        },
+      ])
+    })
   })
 })

--- a/packages/logger/src/factory/factory.test.ts
+++ b/packages/logger/src/factory/factory.test.ts
@@ -52,4 +52,122 @@ describe('logger-factory', () => {
       })
     })
   })
+
+  describe('options.baseMeta', () => {
+    it('includes baseMeta in all log output', () => {
+      const logStream = createTestOutput()
+      const logger = loggerFactory({
+        silent: true,
+        testOutputStream: logStream,
+        baseMeta: {service: 'my-service', env: 'test'},
+      })
+
+      logger.info('hello')
+
+      expect(JSON.parse(logStream.toString())).toStrictEqual(
+        expect.objectContaining({
+          service: 'my-service',
+          env: 'test',
+          message: 'hello',
+        })
+      )
+    })
+  })
+
+  describe('options.logLevel', () => {
+    it('suppresses messages below the configured level', () => {
+      const logStream = createTestOutput()
+      const logger = loggerFactory({
+        silent: true,
+        testOutputStream: logStream,
+        logLevel: 'warn',
+      })
+
+      logger.info('should be hidden')
+      logger.warn('should appear')
+
+      expect(logStream).toHaveLogged([
+        expect.objectContaining({level: 'warn', message: 'should appear'}),
+      ])
+    })
+  })
+
+  describe('log() method', () => {
+    it('delegates to the correct level method when level is a string', () => {
+      const logStream = createTestOutput()
+      const logger = loggerFactory({silent: true, testOutputStream: logStream})
+
+      logger.log('info', 'via log method')
+
+      expect(logStream).toHaveLogged([
+        expect.objectContaining({level: 'info', message: 'via log method'}),
+      ])
+    })
+
+    it('delegates correctly when given a LogEntry object', () => {
+      const logStream = createTestOutput()
+      const logger = loggerFactory({silent: true, testOutputStream: logStream})
+
+      logger.log({level: 'warn', message: 'entry object', extra: 'data'})
+
+      expect(logStream).toHaveLogged([
+        expect.objectContaining({level: 'warn', message: 'entry object', extra: 'data'}),
+      ])
+    })
+
+    it('throws an error for an invalid log level', () => {
+      const logger = loggerFactory({silent: true})
+
+      expect(() => logger.log('nonexistent' as any, 'msg')).toThrow(
+        'invalid log level: nonexistent'
+      )
+    })
+  })
+
+  describe('child() logger', () => {
+    it('creates a child logger that inherits parent config and adds child meta', () => {
+      const logStream = createTestOutput()
+      const logger = loggerFactory({
+        silent: true,
+        testOutputStream: logStream,
+        baseMeta: {service: 'parent'},
+      })
+
+      const child = logger.child({component: 'child'})
+      child.info('from child')
+
+      expect(logStream).toHaveLogged([
+        expect.objectContaining({
+          service: 'parent',
+          component: 'child',
+          message: 'from child',
+        }),
+      ])
+    })
+
+    it('does not add child meta to parent logger output', () => {
+      const logStream = createTestOutput()
+      const logger = loggerFactory({silent: true, testOutputStream: logStream})
+
+      logger.child({component: 'child'})
+      logger.info('from parent')
+
+      const output = JSON.parse(logStream.toString())
+      expect(output).not.toHaveProperty('component')
+    })
+  })
+
+  describe('_output property', () => {
+    it('exposes _output when silent is true in test environment', () => {
+      const logger = loggerFactory({silent: true})
+
+      expect(logger).toHaveProperty('_output')
+    })
+
+    it('does not expose _output when silent is not set', () => {
+      const logger = loggerFactory()
+
+      expect(logger).not.toHaveProperty('_output')
+    })
+  })
 })

--- a/packages/logger/src/format/format-like-winston.test.ts
+++ b/packages/logger/src/format/format-like-winston.test.ts
@@ -1,0 +1,91 @@
+import {formatLikeWinston} from './format-like-winston'
+
+describe('formatLikeWinston', () => {
+  it('handles a simple message string', () => {
+    const [message, meta] = formatLikeWinston('hello world')
+
+    expect(message).toBe('hello world')
+    expect(meta).toStrictEqual({error: undefined})
+  })
+
+  it('extracts error object from "error" key in meta', () => {
+    const error = new Error('test error')
+    const [message, meta] = formatLikeWinston('something failed', {error})
+
+    expect(message).toBe('something failed')
+    expect(meta.error).toBe(error)
+  })
+
+  it('extracts error object from "err" key in meta', () => {
+    const err = new Error('another error')
+    const [message, meta] = formatLikeWinston('something failed', {err})
+
+    expect(message).toBe('something failed')
+    expect(meta.error).toBe(err)
+  })
+
+  it('prefers later meta entries when multiple contain error keys', () => {
+    const firstError = new Error('first')
+    const secondError = new Error('second')
+    const [, meta] = formatLikeWinston('msg', {error: firstError}, {error: secondError})
+
+    expect(meta.error).toBe(secondError)
+  })
+
+  it('handles splat interpolation with %s', () => {
+    const [message, meta] = formatLikeWinston('hello %s', 'world')
+
+    expect(message).toBe('hello world')
+    expect(meta).toStrictEqual({error: undefined})
+  })
+
+  it('handles splat interpolation with %d', () => {
+    const [message] = formatLikeWinston('count: %d items', 42)
+
+    expect(message).toBe('count: 42 items')
+  })
+
+  it('handles splat interpolation with %o', () => {
+    const [message] = formatLikeWinston('data: %o', {key: 'value'})
+
+    expect(message).toBe("data: { key: 'value' }")
+  })
+
+  it('merges remaining meta fields into the returned meta object', () => {
+    const [message, meta] = formatLikeWinston('msg', {extra: 'data', more: 123})
+
+    expect(message).toBe('msg')
+    expect(meta).toStrictEqual({extra: 'data', more: 123, error: undefined})
+  })
+
+  it('handles missing message field gracefully', () => {
+    // @ts-expect-error testing with undefined message
+    const [message, meta] = formatLikeWinston(undefined)
+
+    expect(meta).toStrictEqual({error: undefined})
+    expect(message).toBeUndefined()
+  })
+
+  it('returns fallback when transform returns a boolean', () => {
+    // Verify the function does not throw with empty meta array
+    const [msg, result] = formatLikeWinston('fallback test')
+    expect(msg).toBe('fallback test')
+    expect(result).toStrictEqual({error: undefined})
+  })
+
+  it('handles meta with no error-related keys', () => {
+    const [message, meta] = formatLikeWinston('msg', {foo: 'bar'})
+
+    expect(message).toBe('msg')
+    expect(meta.error).toBeUndefined()
+    expect(meta.foo).toBe('bar')
+  })
+
+  it('handles null values in meta array without crashing', () => {
+    // null is typeof object but should not crash the reduce
+    const [message, meta] = formatLikeWinston('msg', null as any)
+
+    expect(message).toBe('msg')
+    expect(meta.error).toBeUndefined()
+  })
+})

--- a/packages/logger/src/test-utils/WritableMemoryStream.test.ts
+++ b/packages/logger/src/test-utils/WritableMemoryStream.test.ts
@@ -1,0 +1,83 @@
+import {WritableMemoryStream} from './WritableMemoryStream'
+
+describe('WritableMemoryStream', () => {
+  it('writes and stores string chunks', () => {
+    const stream = new WritableMemoryStream()
+
+    stream.write('hello')
+
+    expect(stream.toString()).toBe('hello')
+  })
+
+  it('writes and stores buffer chunks', () => {
+    const stream = new WritableMemoryStream()
+
+    stream.write(Buffer.from('buffer content'))
+
+    expect(stream.toString()).toBe('buffer content')
+  })
+
+  it('handles multiple sequential writes', () => {
+    const stream = new WritableMemoryStream()
+
+    stream.write('first ')
+    stream.write('second ')
+    stream.write('third')
+
+    expect(stream.toString()).toBe('first second third')
+  })
+
+  it('clear() resets the buffer', () => {
+    const stream = new WritableMemoryStream()
+
+    stream.write('some data')
+    expect(stream.toString()).toBe('some data')
+
+    stream.clear()
+    expect(stream.toString()).toBe('')
+  })
+
+  it('accepts new writes after clear()', () => {
+    const stream = new WritableMemoryStream()
+
+    stream.write('before clear')
+    stream.clear()
+    stream.write('after clear')
+
+    expect(stream.toString()).toBe('after clear')
+  })
+
+  it('toString() defaults to utf-8 encoding', () => {
+    const stream = new WritableMemoryStream()
+    const unicodeText = 'hello \u00e4\u00f6\u00fc'
+
+    stream.write(unicodeText)
+
+    expect(stream.toString()).toBe(unicodeText)
+    expect(stream.toString('utf-8')).toBe(unicodeText)
+  })
+
+  it('toString() supports alternate encodings', () => {
+    const stream = new WritableMemoryStream()
+    const content = 'hello'
+
+    stream.write(content)
+
+    const hexResult = stream.toString('hex')
+    expect(hexResult).toBe(Buffer.from(content).toString('hex'))
+  })
+
+  it('starts with an empty buffer', () => {
+    const stream = new WritableMemoryStream()
+
+    expect(stream.toString()).toBe('')
+  })
+
+  it('accepts WritableOptions in constructor', () => {
+    const stream = new WritableMemoryStream({highWaterMark: 1024})
+
+    stream.write('test')
+
+    expect(stream.toString()).toBe('test')
+  })
+})

--- a/packages/logger/src/test-utils/matchers.test.ts
+++ b/packages/logger/src/test-utils/matchers.test.ts
@@ -1,0 +1,81 @@
+import {toHaveLogged} from './matchers'
+
+// Create a minimal Jest matcher context for testing the matcher directly
+function runMatcher(
+  received: {toString: () => string} | {_output: {toString: () => string}},
+  expected: object[]
+): {pass: boolean; message: () => string} {
+  const context = {
+    utils: {
+      printReceived: (val: unknown) => JSON.stringify(val),
+      printExpected: (val: unknown) => JSON.stringify(val),
+      matcherHint: (hint: string) => hint,
+    },
+    equals: (a: unknown, b: unknown) => {
+      try {
+        expect(a).toStrictEqual(b)
+        return true
+      } catch {
+        return false
+      }
+    },
+  }
+
+  return toHaveLogged.call(context as any, received, expected)
+}
+
+function makeStream(lines: object[]): {toString: () => string} {
+  const content = `${lines.map(l => JSON.stringify(l)).join('\n')}\n`
+  return {toString: () => content}
+}
+
+describe('toHaveLogged matcher', () => {
+  it('returns pass: true when messages match', () => {
+    const stream = makeStream([{level: 'info', message: 'hello'}])
+
+    const result = runMatcher(stream, [{level: 'info', message: 'hello'}])
+
+    expect(result.pass).toBe(true)
+  })
+
+  it('returns pass: false when a message does not match', () => {
+    const stream = makeStream([{level: 'info', message: 'hello'}])
+
+    const result = runMatcher(stream, [{level: 'error', message: 'goodbye'}])
+
+    expect(result.pass).toBe(false)
+    expect(result.message()).toContain('error')
+  })
+
+  it('returns pass: false when there are extra received messages', () => {
+    const stream = makeStream([
+      {level: 'info', message: 'first'},
+      {level: 'info', message: 'second'},
+    ])
+
+    const result = runMatcher(stream, [{level: 'info', message: 'first'}])
+
+    expect(result.pass).toBe(false)
+    expect(result.message()).toContain('extra')
+  })
+
+  it('returns pass: false when fewer messages received than expected', () => {
+    const stream = makeStream([{level: 'info', message: 'only one'}])
+
+    const result = runMatcher(stream, [
+      {level: 'info', message: 'only one'},
+      {level: 'info', message: 'missing'},
+    ])
+
+    expect(result.pass).toBe(false)
+  })
+
+  it('accepts a Logger-like object with _output property', () => {
+    const innerStream = makeStream([{level: 'warn', message: 'test'}])
+    const loggerLike = {_output: innerStream}
+
+    const result = runMatcher(loggerLike, [{level: 'warn', message: 'test'}])
+
+    expect(result.pass).toBe(true)
+  })
+})

--- a/packages/logger/src/types/logger.d.ts
+++ b/packages/logger/src/types/logger.d.ts
@@ -21,7 +21,7 @@ export type LeveledLogger<L extends string> = {
 export type Logger<L extends string = LogLevel> = {
   log: LogMethod<L>
   child(meta: object): Logger<L>
-  level: L,
+  level: L
 } & LeveledLogger<L>
 
 export type LogLevel = 'silent' | 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace'

--- a/packages/middleware/src/index.test.ts
+++ b/packages/middleware/src/index.test.ts
@@ -29,6 +29,86 @@ describe('createMiddlewareStack', () => {
     expect(middlewares).toHaveLength(4)
   })
 
+  describe('individual feature toggles', () => {
+    it('adds only context provider when others are disabled', () => {
+      const middlewares = createMiddlewareStack({
+        withHttpContextProvider: true,
+        withRequestIdProvider: false,
+        withLoggerProvider: false,
+        withRequestLogging: false,
+      })
+
+      expect(middlewares).toHaveLength(1)
+    })
+
+    it('adds context + requestId when only those are enabled', () => {
+      const middlewares = createMiddlewareStack({
+        withHttpContextProvider: true,
+        withRequestIdProvider: true,
+        withLoggerProvider: false,
+        withRequestLogging: false,
+      })
+
+      expect(middlewares).toHaveLength(2)
+    })
+
+    it('adds context + logger provider when only those are enabled', () => {
+      const middlewares = createMiddlewareStack({
+        withHttpContextProvider: true,
+        withRequestIdProvider: false,
+        withLoggerProvider: true,
+        loggerProviderOptions: {logger: testLogger},
+        withRequestLogging: false,
+      })
+
+      expect(middlewares).toHaveLength(2)
+    })
+
+    it('adds context + requestId + logger when request logging is disabled', () => {
+      const middlewares = createMiddlewareStack({
+        withHttpContextProvider: true,
+        withRequestIdProvider: true,
+        withLoggerProvider: true,
+        loggerProviderOptions: {logger: testLogger},
+        withRequestLogging: false,
+      })
+
+      expect(middlewares).toHaveLength(3)
+    })
+  })
+
+  describe('attach()', () => {
+    it('calls use() on the target for each middleware', () => {
+      const middlewares = createMiddlewareStack({
+        loggerProviderOptions: {logger: testLogger},
+      })
+
+      const mockApp = {use: jest.fn()}
+      middlewares.attach(mockApp)
+
+      expect(mockApp.use).toHaveBeenCalledTimes(4)
+      for (let i = 0; i < 4; i++) {
+        expect(typeof mockApp.use.mock.calls[i][0]).toBe('function')
+      }
+    })
+  })
+
+  describe('middleware ordering', () => {
+    it('adds middlewares in the correct order: context → requestId → logger → requestLogging', () => {
+      const middlewares = createMiddlewareStack({
+        loggerProviderOptions: {logger: testLogger},
+      })
+
+      expect(middlewares).toHaveLength(4)
+      // All entries should be functions (middleware handlers)
+      middlewares.forEach(mw => {
+        expect(typeof mw).toBe('function')
+      })
+      // The first middleware is the http context provider (named function)
+      expect(middlewares[0].name).toBe('httpContextMiddleware')
+    })
+  })
+
   describe('integration', () => {
     let app: express.Express
     const handler = jest.fn((req, res) => {
@@ -79,13 +159,34 @@ describe('createMiddlewareStack', () => {
 
       // req had the correct properties attached
       expect(innerReq!.requestId).toBe('req-1')
-      expect(innerReq!.logger.info).toBeFunction()
+      expect(typeof innerReq!.logger.info).toBe('function')
 
       // req had the correct headers added
       expect(innerReq!.header('x-request-id')).toBe('req-1')
 
       // request id was correctly added to http context
       expect(requestIdFromContext!).toBe('req-1')
+    })
+
+    it('works with request logging but without logger provider using custom loggerAccessor', async () => {
+      const customLogger = loggerFactory({silent: true})
+
+      const middlewares = createMiddlewareStack({
+        withHttpContextProvider: true,
+        withRequestIdProvider: false,
+        withLoggerProvider: false,
+        withRequestLogging: true,
+        requestLoggingOptions: {
+          loggerAccessor: () => customLogger,
+        },
+      })
+
+      middlewares.attach(app)
+      app.get('/test', (_req, res) => {
+        res.status(200).json({ok: true})
+      })
+
+      await request(app).get('/test').expect(200)
     })
   })
 })

--- a/packages/middleware/src/utils.test.ts
+++ b/packages/middleware/src/utils.test.ts
@@ -1,0 +1,99 @@
+import {
+  isEnabledContextProviderOption,
+  isEnabledRequestIdProviderOption,
+  isEnabledLoggerProviderOption,
+  isEnabledRequestLoggingOption,
+} from './utils'
+
+describe('isEnabledContextProviderOption', () => {
+  it('returns false when withHttpContextProvider is false', () => {
+    expect(isEnabledContextProviderOption({withHttpContextProvider: false})).toBe(false)
+  })
+
+  it('returns true when withHttpContextProvider is true', () => {
+    expect(isEnabledContextProviderOption({withHttpContextProvider: true})).toBe(true)
+  })
+
+  it('returns false when withHttpContextProvider is undefined', () => {
+    expect(isEnabledContextProviderOption({})).toBe(false)
+  })
+})
+
+describe('isEnabledRequestIdProviderOption', () => {
+  it('returns false when withRequestIdProvider is false', () => {
+    expect(isEnabledRequestIdProviderOption({withRequestIdProvider: false})).toBe(false)
+  })
+
+  it('returns true when withRequestIdProvider is true', () => {
+    expect(isEnabledRequestIdProviderOption({withRequestIdProvider: true})).toBe(true)
+  })
+
+  it('returns true when withRequestIdProvider is true with custom options', () => {
+    expect(
+      isEnabledRequestIdProviderOption({
+        withRequestIdProvider: true,
+        requestIdProviderOptions: {
+          requestIdGenerator: () => 'custom-id',
+        },
+      })
+    ).toBe(true)
+  })
+
+  it('returns false when withRequestIdProvider is undefined', () => {
+    expect(isEnabledRequestIdProviderOption({} as any)).toBe(false)
+  })
+})
+
+describe('isEnabledLoggerProviderOption', () => {
+  it('returns false when withLoggerProvider is false', () => {
+    expect(isEnabledLoggerProviderOption({withLoggerProvider: false})).toBe(false)
+  })
+
+  it('returns true when withLoggerProvider is true', () => {
+    expect(
+      isEnabledLoggerProviderOption({
+        withLoggerProvider: true,
+        loggerProviderOptions: {logger: {info: jest.fn(), error: jest.fn()} as any},
+      })
+    ).toBe(true)
+  })
+
+  it('returns true when withLoggerProvider is true with custom logger options', () => {
+    const mockLogger = {info: jest.fn(), error: jest.fn(), warn: jest.fn()}
+    expect(
+      isEnabledLoggerProviderOption({
+        withLoggerProvider: true,
+        loggerProviderOptions: {logger: mockLogger as any},
+      })
+    ).toBe(true)
+  })
+
+  it('returns false when withLoggerProvider is undefined', () => {
+    expect(isEnabledLoggerProviderOption({} as any)).toBe(false)
+  })
+})
+
+describe('isEnabledRequestLoggingOption', () => {
+  it('returns false when withRequestLogging is false', () => {
+    expect(isEnabledRequestLoggingOption({withRequestLogging: false})).toBe(false)
+  })
+
+  it('returns true when withRequestLogging is true', () => {
+    expect(isEnabledRequestLoggingOption({withRequestLogging: true})).toBe(true)
+  })
+
+  it('returns true when withRequestLogging is true with custom options', () => {
+    expect(
+      isEnabledRequestLoggingOption({
+        withRequestLogging: true,
+        requestLoggingOptions: {
+          loggerAccessor: () => ({info: jest.fn()} as any),
+        },
+      } as any)
+    ).toBe(true)
+  })
+
+  it('returns false when withRequestLogging is undefined', () => {
+    expect(isEnabledRequestLoggingOption({} as any)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI workflow (build, typecheck, lint, test on pushes to master and PRs)
- Add Claude Code agents and hooks for auto lint/format
- Improve test coverage across all packages (53 test files changed, ~3100 lines added)

### Test coverage added for:
- `middleware/http-context-provider` — context storage, middleware, read-write, integration
- `middleware/request-id-provider` — UUID validation, header options, edge cases
- `middleware/logger-provider` — child logger creation, independent requests
- `middleware/request-logging` — middleware factory options, defaults, utils, type guards
- `middleware/apollo-server-logging` — full plugin lifecycle, all config options, defaults, utils
- `middleware/apollo-server-v4-logging` — full plugin lifecycle, all config options, defaults, utils
- `packages/logger` — factory options, log() method, child loggers, format-like-winston, WritableMemoryStream, toHaveLogged matcher, error cause chains
- `packages/middleware` — feature toggles, attach(), middleware ordering, custom loggerAccessor integration

### Also fixed:
- Pre-existing `toBeFunction()` failure in `packages/middleware` integration test (`jest-extended` not resolving)

## Test plan
- [x] `yarn test` passes all tests across all packages
- [x] `yarn typecheck` passes for all packages